### PR TITLE
Add dark mode toggle

### DIFF
--- a/config/i18n/en-US.json
+++ b/config/i18n/en-US.json
@@ -7,7 +7,8 @@
     "DataRepo": "Data",
     "Issues": "Feedback",
     "Forum": "Forum",
-    "Github": "by ControlNet"
+    "Github": "by ControlNet",
+    "DarkMode": "Dark Mode"
   },
   "Sidebar": {
     "Date": {

--- a/config/i18n/zh-CN.json
+++ b/config/i18n/zh-CN.json
@@ -7,7 +7,8 @@
     "DataRepo": "数据",
     "Issues": "反馈",
     "Forum": "论坛",
-    "Github": "作者ControlNet"
+    "Github": "作者ControlNet",
+    "DarkMode": "深色模式"
   },
   "Sidebar": {
     "Date": {

--- a/index.css
+++ b/index.css
@@ -1,3 +1,13 @@
+body {
+    background-color: white;
+    color: black;
+}
+
+body.dark-mode {
+    background-color: #000;
+    color: #EEFFFF;
+}
+
 ul#navbar {
     list-style-type: none;
     margin: 0;
@@ -30,6 +40,22 @@ ul#navbar > li > a {
     text-align: center;
     padding: 14px 16px;
     text-decoration: none;
+}
+
+ul#navbar > li > label {
+    display: block;
+    color: #EEFFFF;
+    text-align: center;
+    padding: 14px 16px;
+    cursor: pointer;
+}
+
+ul#navbar > li > label:hover {
+    background-color: #616161;
+}
+
+ul#navbar > li > label > input {
+    margin-left: 4px;
 }
 
 ul#navbar > li > a.link-tab {

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -174,7 +174,8 @@ interface LocalizationJson {
         readonly DataRepo: string,
         readonly Issues: string,
         readonly Forum: string,
-        readonly Github: string
+        readonly Github: string,
+        readonly DarkMode: string
     }
 
     readonly Sidebar: {
@@ -269,6 +270,9 @@ class NavbarLocalization extends AbstractLocalization {
     }
     get Github(): string {
         return `${this.class}.${this.layout}.Github`;
+    }
+    get DarkMode(): string {
+        return `${this.class}.${this.layout}.DarkMode`;
     }
 }
 

--- a/src/app/link/dark-mode-toggle.ts
+++ b/src/app/link/dark-mode-toggle.ts
@@ -1,0 +1,35 @@
+import { Link } from "./link";
+import { Inject, Singleton } from "../../utils";
+import { Localization } from "../config";
+import * as d3 from "d3";
+
+@Singleton(DarkModeToggle)
+export class DarkModeToggle extends Link {
+    @Inject(Localization.Navbar.DarkMode) readonly name: string;
+    readonly id = "dark-mode-checkbox";
+    readonly url = "#";
+    private checkbox: d3.Selection<HTMLInputElement, unknown, HTMLElement, any>;
+
+    private applyMode(enabled: boolean) {
+        d3.select("body").classed("dark-mode", enabled);
+    }
+
+    init(): void {
+        const li = this.navbar.append<HTMLLIElement>("li");
+        const label = li.append<HTMLLabelElement>("label")
+            .text(this.name);
+        this.checkbox = label.append<HTMLInputElement>("input")
+            .attr("type", "checkbox")
+            .attr("id", this.id);
+
+        const saved = localStorage.getItem(this.id) === "true";
+        this.checkbox.property("checked", saved);
+        this.applyMode(saved);
+
+        this.checkbox.on("change", () => {
+            const checked = this.checkbox.property("checked") as boolean;
+            localStorage.setItem(this.id, checked.toString());
+            this.applyMode(checked);
+        });
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,10 +8,11 @@ import { GithubLink } from "./app/link/github-link";
 import { Logo } from "./app/image/logo";
 import { GithubIssue } from "./app/link/github-issue";
 import { Forum } from "./app/link/forum";
+import { DarkModeToggle } from "./app/link/dark-mode-toggle";
 
 Application.build
     .withLogo(Logo)
     .withPages(BRHeatMapPage, StackedAreaPage, TodoPage)
-    .withLinks(WebRepo, DataRepo, GithubIssue, Forum, GithubLink)
+    .withLinks(WebRepo, DataRepo, GithubIssue, Forum, GithubLink, DarkModeToggle)
     .class
     .run()


### PR DESCRIPTION
## Summary
- enable dark mode via a navbar checkbox
- provide i18n strings for the toggle
- style navbar labels and new dark mode classes

## Testing
- `npm run build` *(fails: Cannot find module 'wasm-utils')*

------
https://chatgpt.com/codex/tasks/task_e_68461da678a8832cbe2532180f737e31