### PR TITLE
Fix metadata fetch URL to avoid CORS

### DIFF
--- a/src/app/application.ts
+++ b/src/app/application.ts
@@ -30,7 +30,9 @@ export class Application {
 
     static run(): void {
 
-        d3.json(`${DATA_BASE}/metadata.json`, async (metadata: Array<Metadata>) => {
+        d3.json(
+            "https://raw.githubusercontent.com/controlnet/wt-data-project.data/main/metadata.json",
+            async (metadata: Array<Metadata>) => {
             // load wasm module
             await WasmUtils.init();
             // init Container constants


### PR DESCRIPTION
## Summary
- fetch metadata.json from raw.githubusercontent.com instead of GitHub Pages

## Testing
- `npm install`
- `npm run build` *(fails: unable to locate wasm glob)*

------
https://chatgpt.com/codex/tasks/task_e_684d9ca20c90832c827459c1572b25f1