### PR TITLE
Fix Localization injection

### DIFF
--- a/src/app/page/br-heatmap-page.ts
+++ b/src/app/page/br-heatmap-page.ts
@@ -1,5 +1,6 @@
 import { Page } from "./page";
 import { Container, Inject, Singleton, utils } from "../../utils";
+import { LazyServiceIdentifer } from "inversify";
 import { BrHeatmap } from "../../plot/br-heatmap";
 import { Sidebar } from "../global-env";
 import { BrRangeSelect, ClassSelect, DateSelect, MeasurementSelect, ModeSelect, Select } from "../sidebar/select";
@@ -13,7 +14,7 @@ import { Checkbox, ColorblindCheckbox } from "../sidebar/checkbox";
 export class BRHeatMapPage extends Page {
     plot: BrHeatmap;
     readonly id = "br-heatmap";
-    @Inject(Localization.Navbar.BrHeatmap) readonly name: string;
+    @Inject(new LazyServiceIdentifer(() => Localization.Navbar.BrHeatmap)) readonly name: string;
     @Inject(Sidebar) sidebar: d3.Selection<HTMLDivElement, unknown, HTMLElement, any>;
 
     update(): void {

--- a/src/app/page/stacked-area-page.ts
+++ b/src/app/page/stacked-area-page.ts
@@ -6,13 +6,14 @@ import { ClassSelect, ModeSelect, ScaleSelect, Select } from "../sidebar/select"
 import { StackedLineChart } from "../../plot/line-chart";
 import { Clazz, Mode, Scale } from "../options";
 import { Localization } from "../config";
+import { LazyServiceIdentifer } from "inversify";
 
 
 @Singleton(StackedAreaPage)
 export class StackedAreaPage extends Page {
     plot: StackedLineChart;
     readonly id = "stacked-area";
-    @Inject(Localization.Navbar.StackedArea) readonly name: string;
+    @Inject(new LazyServiceIdentifer(() => Localization.Navbar.StackedArea)) readonly name: string;
     @Inject(Sidebar) sidebar: d3.Selection<HTMLDivElement, unknown, HTMLElement, any>;
 
     update(): void {

--- a/src/app/page/todo-page.ts
+++ b/src/app/page/todo-page.ts
@@ -3,12 +3,13 @@ import * as d3 from "d3";
 import * as marked from "marked";
 import { Inject, Singleton } from "../../utils";
 import { Localization } from "../config";
+import { LazyServiceIdentifer } from "inversify";
 
 
 @Singleton(TodoPage)
 export class TodoPage extends Page {
     readonly id = "todo-list";
-    @Inject(Localization.Navbar.TodoList) readonly name = "Todo List";
+    @Inject(new LazyServiceIdentifer(() => Localization.Navbar.TodoList)) readonly name = "Todo List";
 
     update(): void {
         // remove old content of previous page


### PR DESCRIPTION
## Summary
- use LazyServiceIdentifer for `Localization` injections in pages

## Testing
- `npm run build` *(fails: unable to locate wasm glob)*

------
https://chatgpt.com/codex/tasks/task_e_684de77712e4832c9488806199e9e001