### PR TITLE
Add Ground RB vehicle card gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ This fork preserves upstream attribution and AGPL source availability:
 
 The app displays the prepared data date from `/data/metadata.json`. Thunderskill-derived data is sample-based, and joined data may contain imperfect vehicle matching, so low-sample rows should be treated as directional rather than definitive.
 
+The Ground RB card gallery uses generated placeholder panels for vehicles. The current upstream `joined` and `wk` CSV snapshots do not include safe vehicle image URLs, thumbnails, rank fields, or finer vehicle-type labels. If a future data-preparation pipeline adds licensed image URLs or local attributed assets, the card image area can be wired to that source.
+
 ## Features
 
 Mouse tooltip in heatmap.

--- a/index.css
+++ b/index.css
@@ -899,3 +899,265 @@ input:focus-visible{
   }
 }
 
+/* ---------- Ground RB vehicle card gallery ---------- */
+.results-toolbar{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  flex-wrap:wrap;
+  gap:10px;
+  margin:14px 0;
+  padding:10px;
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  background:linear-gradient(180deg, rgba(15,23,32,.92), rgba(8,12,18,.92));
+  color:#e8f4ff;
+  box-shadow:var(--shadow);
+}
+
+body:not(.dark-mode) .results-toolbar{
+  background:linear-gradient(180deg, #162130, #0e1723);
+}
+
+.results-toolbar label{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  font-weight:800;
+}
+
+.results-toolbar select{
+  min-height:var(--tap);
+  border:1px solid rgba(137,221,255,.28);
+  border-radius:10px;
+  background:#111b27;
+  color:#e8f4ff;
+  padding:8px 10px;
+  font:inherit;
+}
+
+.view-toggle{
+  display:flex;
+  gap:6px;
+  padding:4px;
+  border:1px solid rgba(137,221,255,.2);
+  border-radius:12px;
+  background:rgba(255,255,255,.04);
+}
+
+.view-toggle button{
+  min-height:38px;
+  border-color:transparent;
+  background:transparent;
+  color:#d6e8f6;
+}
+
+.view-toggle button[aria-pressed="true"]{
+  background:linear-gradient(180deg, #2a5c7d, #17384e);
+  color:#ffffff;
+  box-shadow:0 0 0 1px rgba(137,221,255,.22), 0 8px 22px rgba(37,194,255,.16);
+}
+
+.result-count{
+  color:#b9c9d6;
+  font-weight:800;
+}
+
+.ground-card-view{
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(230px, 1fr));
+  gap:14px;
+  margin:14px 0;
+}
+
+.vehicle-card{
+  overflow:hidden;
+  border:1px solid rgba(137,221,255,.16);
+  border-radius:16px;
+  background:
+    linear-gradient(180deg, rgba(28,37,47,.96), rgba(12,17,22,.98)),
+    var(--panel);
+  color:#eaf6ff;
+  box-shadow:0 14px 34px rgba(0,0,0,.28);
+}
+
+body:not(.dark-mode) .vehicle-card{
+  background:linear-gradient(180deg, #1b2633, #111820);
+}
+
+.vehicle-card.low-sample-card{
+  border-color:rgba(255,203,107,.38);
+}
+
+.vehicle-art{
+  min-height:118px;
+  position:relative;
+  display:flex;
+  align-items:flex-end;
+  justify-content:space-between;
+  padding:12px;
+  background:
+    radial-gradient(circle at 28% 40%, rgba(125,159,180,.22), transparent 9rem),
+    linear-gradient(135deg, rgba(50,65,76,.86), rgba(15,22,29,.92) 58%, rgba(28,38,26,.8));
+  border-bottom:1px solid rgba(137,221,255,.12);
+}
+
+.vehicle-art:before{
+  content:"";
+  position:absolute;
+  inset:18px 22px;
+  border:1px solid rgba(232,244,255,.08);
+  border-radius:60% 40% 54% 46%;
+  background:linear-gradient(90deg, transparent, rgba(232,244,255,.08), transparent);
+  transform:skewX(-12deg);
+}
+
+.vehicle-art-mark,
+.vehicle-art-name{
+  position:relative;
+  z-index:1;
+  border:1px solid rgba(232,244,255,.14);
+  border-radius:999px;
+  background:rgba(5,9,13,.55);
+  padding:5px 8px;
+  color:#cbd8e3;
+  font-weight:900;
+  letter-spacing:.05em;
+  font-size:.8rem;
+}
+
+.vehicle-card-body{
+  padding:14px;
+}
+
+.vehicle-card h3{
+  margin:0 0 10px;
+  color:#ffffff;
+  font-size:1.05rem;
+  line-height:1.2;
+}
+
+.badge-row{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+  margin-bottom:12px;
+}
+
+.badge-row span{
+  border:1px solid rgba(137,221,255,.14);
+  border-radius:999px;
+  background:rgba(137,221,255,.08);
+  color:#b8c7d4;
+  padding:3px 7px;
+  font-size:.78rem;
+  font-weight:850;
+}
+
+.badge-row .premium-badge{
+  border-color:rgba(255,203,107,.3);
+  background:rgba(255,203,107,.14);
+  color:#ffd86b;
+}
+
+.stat-grid{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:1px;
+  margin:0;
+  overflow:hidden;
+  border:1px solid rgba(137,221,255,.1);
+  border-radius:12px;
+  background:rgba(137,221,255,.08);
+}
+
+.stat-grid div{
+  min-width:0;
+  padding:8px;
+  background:rgba(4,8,12,.34);
+}
+
+.stat-grid dt{
+  color:#8fa0af;
+  font-size:.76rem;
+  font-weight:800;
+}
+
+.stat-grid dd{
+  margin:2px 0 0;
+  color:#ffffff;
+  font-size:.95rem;
+  font-weight:900;
+}
+
+.card-caveat{
+  margin:10px 0 0;
+  color:#ffd86b;
+  font-size:.86rem;
+}
+
+.card-actions{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:8px;
+  margin-top:12px;
+}
+
+.card-actions button{
+  min-height:42px;
+  border-color:rgba(137,221,255,.18);
+  background:rgba(137,221,255,.08);
+  color:#e9f7ff;
+}
+
+.card-actions button:hover{
+  background:rgba(37,194,255,.18);
+}
+
+.card-more-wrap{
+  text-align:center;
+  margin:8px 0 16px;
+}
+
+#show-more-cards{
+  min-width:180px;
+  background:linear-gradient(180deg, #25384a, #172331);
+  color:#eaf6ff;
+}
+
+@media (min-width:1300px){
+  .ground-card-view{
+    grid-template-columns:repeat(5, minmax(0, 1fr));
+  }
+}
+
+@media (max-width:1050px){
+  .ground-card-view{
+    grid-template-columns:repeat(auto-fit, minmax(250px, 1fr));
+  }
+}
+
+@media (max-width:640px){
+  .results-toolbar,
+  .results-toolbar label{
+    align-items:stretch;
+    flex-direction:column;
+  }
+
+  .view-toggle{
+    width:100%;
+  }
+
+  .view-toggle button{
+    flex:1 1 0;
+  }
+
+  .ground-card-view{
+    grid-template-columns:1fr;
+  }
+
+  .stat-grid{
+    grid-template-columns:1fr 1fr;
+  }
+}
+

--- a/src/app/ground-rb-panel.ts
+++ b/src/app/ground-rb-panel.ts
@@ -17,6 +17,8 @@ type JoinedRow = {
     rb_win_rate: string;
     rb_ground_frags_per_battle: string;
     rb_ground_frags_per_death: string;
+    rb_rp_rate: string;
+    rb_sl_rate: string;
     is_premium: string;
 };
 
@@ -41,6 +43,10 @@ type Filters = {
 const STORAGE_RECENT = "wt-ground-rb-recent-searches";
 const STORAGE_FAVORITES = "wt-ground-rb-favorites";
 const STORAGE_COMPARE = "wt-ground-rb-compare";
+const CARD_PAGE_SIZE = 50;
+
+type SortMode = "win" | "played" | "gkd" | "gkb" | "brAsc" | "brDesc" | "name";
+type ViewMode = "card" | "table";
 
 export class GroundRbPanel {
     private root: HTMLElement;
@@ -51,6 +57,9 @@ export class GroundRbPanel {
     private compareNames: string[] = [];
     private favorites: string[] = [];
     private recentSearches: string[] = [];
+    private currentSort: SortMode = "win";
+    private currentView: ViewMode = "card";
+    private visibleCards = CARD_PAGE_SIZE;
 
     constructor(metadata: Metadata[]) {
         this.metadata = metadata;
@@ -142,11 +151,31 @@ export class GroundRbPanel {
                     <div><strong>Favourites</strong><span id="favorite-vehicles"></span></div>
                 </div>
             </details>
-            <div class="ground-rb-results-wrap">
+            <div class="results-toolbar" aria-label="Vehicle result display controls">
+                <label>Sort
+                    ${this.selectBare("ground-sort", [
+                        ["win", "Win rate descending"],
+                        ["played", "Battles descending"],
+                        ["gkd", "Ground kills per death descending"],
+                        ["gkb", "Ground kills per battle descending"],
+                        ["brAsc", "BR ascending"],
+                        ["brDesc", "BR descending"],
+                        ["name", "Name A-Z"]
+                    ])}
+                </label>
+                <div class="view-toggle" role="group" aria-label="View mode">
+                    <button type="button" id="view-card" aria-pressed="true">Card view</button>
+                    <button type="button" id="view-table" aria-pressed="false">Table view</button>
+                </div>
+                <span id="result-count" class="result-count"></span>
+            </div>
+            <div id="ground-card-view" class="ground-card-view"></div>
+            <div class="card-more-wrap"><button type="button" id="show-more-cards">Show more</button></div>
+            <div id="ground-table-view" class="ground-rb-results-wrap" hidden>
                 <table class="ground-rb-results" aria-label="Ground RB vehicle results">
                     <thead>
                         <tr>
-                            <th>Vehicle</th><th>Nation</th><th>BR</th><th>Win</th><th>Battles</th><th>G/K</th><th>G/D</th><th>Premium</th><th></th>
+                            <th>Vehicle</th><th>Nation</th><th>BR</th><th>Rank</th><th>Win</th><th>Battles</th><th>G/K</th><th>G/D</th><th>Premium</th><th></th>
                         </tr>
                     </thead>
                     <tbody id="ground-results"></tbody>
@@ -160,6 +189,7 @@ export class GroundRbPanel {
                 <h3>Data, Source, And License</h3>
                 <p>Fork source: <a href="${this.sourceInfo.forkRepo}">zeoce/wt-data-project.web</a>. Upstream web: <a href="${this.sourceInfo.upstreamWebRepo}">ControlNet/wt-data-project.web</a>. Upstream data: <a href="${this.sourceInfo.upstreamDataRepo}">ControlNet/wt-data-project.data</a>.</p>
                 <p>This AGPL project keeps source availability and upstream attribution visible. Thunderskill-derived data is sample-based, and joined vehicle matching may contain errors. Treat low-sample rows as directional, not definitive.</p>
+                <p>Vehicle cards use local placeholder art because the current joined and wk data snapshots do not include safe image URLs, thumbnails, ranks, or finer vehicle-type fields. Ground frags and deaths on cards are estimates derived from battles and per-battle/per-death rates.</p>
                 <p>Prepared: ${this.formatDate(this.sourceInfo.generatedAt)}. Latest data date: ${latest ? this.escape(latest.date) : "N/A"}.</p>
             </aside>
         `;
@@ -172,6 +202,16 @@ export class GroundRbPanel {
     private bindEvents(): void {
         ["ground-nation", "ground-br-min", "ground-br-max", "ground-premium", "ground-min-battles", "ground-search"]
             .forEach(id => this.byId(id).addEventListener("input", () => this.updateResults()));
+        this.byId("ground-sort").addEventListener("change", () => {
+            this.currentSort = (this.byId("ground-sort") as HTMLSelectElement).value as SortMode;
+            this.updateResults();
+        });
+        this.byId("view-card").addEventListener("click", () => this.setView("card"));
+        this.byId("view-table").addEventListener("click", () => this.setView("table"));
+        this.byId("show-more-cards").addEventListener("click", () => {
+            this.visibleCards += CARD_PAGE_SIZE;
+            this.updateResults();
+        });
 
         this.byId("preset-win").addEventListener("click", () => this.applyPreset("win"));
         this.byId("preset-played").addEventListener("click", () => this.applyPreset("played"));
@@ -185,7 +225,58 @@ export class GroundRbPanel {
         }
     }
 
-    private updateResults(sort: "win" | "played" | "frags" = "win"): void {
+    private setView(view: ViewMode): void {
+        this.currentView = view;
+        (this.byId("ground-card-view") as HTMLElement).hidden = view !== "card";
+        (this.byId("ground-table-view") as HTMLElement).hidden = view !== "table";
+        (this.byId("show-more-cards") as HTMLButtonElement).hidden = view !== "card";
+        this.byId("view-card").setAttribute("aria-pressed", String(view === "card"));
+        this.byId("view-table").setAttribute("aria-pressed", String(view === "table"));
+        this.updateResults();
+    }
+
+    private bindCardButtons(container: HTMLElement): void {
+        Array.prototype.forEach.call(container.querySelectorAll("[data-select]"), (button: HTMLButtonElement) => {
+            button.addEventListener("click", () => this.selectVehicle(button.getAttribute("data-select")));
+        });
+        Array.prototype.forEach.call(container.querySelectorAll("[data-compare]"), (button: HTMLButtonElement) => {
+            button.addEventListener("click", () => this.toggleCompare(button.getAttribute("data-compare")));
+        });
+        Array.prototype.forEach.call(container.querySelectorAll("[data-fav-toggle]"), (button: HTMLButtonElement) => {
+            button.addEventListener("click", () => {
+                const name = button.getAttribute("data-fav-toggle");
+                if (!name) return;
+                this.toggleName(this.favorites, name, STORAGE_FAVORITES, 99);
+                this.renderMemory();
+                this.updateResults();
+            });
+        });
+        Array.prototype.forEach.call(container.querySelectorAll("[data-show-plot]"), (button: HTMLButtonElement) => {
+            button.addEventListener("click", () => this.showLegacyPlot(button.getAttribute("data-show-plot")));
+        });
+    }
+
+    private compareRows(a: JoinedRow, b: JoinedRow): number {
+        switch (this.currentSort) {
+            case "played":
+                return this.toNumber(b.rb_battles) - this.toNumber(a.rb_battles);
+            case "gkd":
+                return this.toNumber(b.rb_ground_frags_per_death) - this.toNumber(a.rb_ground_frags_per_death);
+            case "gkb":
+                return this.toNumber(b.rb_ground_frags_per_battle) - this.toNumber(a.rb_ground_frags_per_battle);
+            case "brAsc":
+                return this.toNumber(a.rb_br) - this.toNumber(b.rb_br);
+            case "brDesc":
+                return this.toNumber(b.rb_br) - this.toNumber(a.rb_br);
+            case "name":
+                return this.displayName(a).localeCompare(this.displayName(b));
+            case "win":
+            default:
+                return this.toNumber(b.rb_win_rate) - this.toNumber(a.rb_win_rate);
+        }
+    }
+
+    private updateResults(): void {
         const filters = this.filters();
         let results = this.rows
             .filter(row => filters.nation === "all" || row.nation === filters.nation)
@@ -194,23 +285,25 @@ export class GroundRbPanel {
             .filter(row => this.toNumber(row.rb_battles) >= filters.minBattles)
             .filter(row => this.matchesQuery(row, filters.query));
 
-        results = results.sort((a, b) => {
-            if (sort === "played") return this.toNumber(b.rb_battles) - this.toNumber(a.rb_battles);
-            if (sort === "frags") return this.toNumber(b.rb_ground_frags_per_battle) - this.toNumber(a.rb_ground_frags_per_battle);
-            return this.toNumber(b.rb_win_rate) - this.toNumber(a.rb_win_rate);
-        }).slice(0, 30);
+        results = results.sort((a, b) => this.compareRows(a, b));
+        this.byId("result-count").textContent = `${results.length} vehicles`;
 
         const tbody = this.byId("ground-results");
-        tbody.innerHTML = results.map(row => this.resultRow(row, filters.minBattles)).join("");
+        tbody.innerHTML = results.slice(0, 100).map((row, index) => this.resultRow(row, filters.minBattles, index + 1)).join("");
         Array.prototype.forEach.call(tbody.querySelectorAll("[data-select]"), (button: HTMLButtonElement) => {
             button.addEventListener("click", () => this.selectVehicle(button.getAttribute("data-select")));
         });
         Array.prototype.forEach.call(tbody.querySelectorAll("[data-compare]"), (button: HTMLButtonElement) => {
             button.addEventListener("click", () => this.toggleCompare(button.getAttribute("data-compare")));
         });
+
+        const visible = results.slice(0, this.visibleCards);
+        this.byId("ground-card-view").innerHTML = visible.map((row, index) => this.vehicleCard(row, filters.minBattles, index + 1)).join("");
+        this.bindCardButtons(this.byId("ground-card-view"));
+        (this.byId("show-more-cards") as HTMLButtonElement).hidden = results.length <= this.visibleCards || this.currentView !== "card";
     }
 
-    private resultRow(row: JoinedRow, minBattles: number): string {
+    private resultRow(row: JoinedRow, minBattles: number, rank: number): string {
         const battles = this.toNumber(row.rb_battles);
         const low = battles < minBattles * 2 ? " low-sample" : "";
         const compared = this.compareNames.indexOf(row.name) >= 0;
@@ -219,6 +312,7 @@ export class GroundRbPanel {
                 <td><button type="button" data-select="${this.escape(row.name)}">${this.displayName(row)}</button></td>
                 <td>${this.escape(row.nation)}</td>
                 <td>${this.formatValue(row.rb_br)}</td>
+                <td>#${rank}</td>
                 <td>${this.formatValue(row.rb_win_rate)}%</td>
                 <td>${this.formatValue(row.rb_battles)}</td>
                 <td>${this.formatValue(row.rb_ground_frags_per_battle)}</td>
@@ -226,6 +320,48 @@ export class GroundRbPanel {
                 <td>${this.isPremium(row) ? "Yes" : "No"}</td>
                 <td><button type="button" data-compare="${this.escape(row.name)}">${compared ? "Remove" : "Compare"}</button></td>
             </tr>
+        `;
+    }
+
+    private vehicleCard(row: JoinedRow, minBattles: number, rank: number): string {
+        const compared = this.compareNames.indexOf(row.name) >= 0;
+        const favorite = this.favorites.indexOf(row.name) >= 0;
+        const lowSample = this.toNumber(row.rb_battles) < minBattles * 2;
+        return `
+            <article class="vehicle-card${lowSample ? " low-sample-card" : ""}" data-nation="${this.escape(row.nation)}">
+                <div class="vehicle-art" aria-hidden="true">
+                    <div class="vehicle-art-mark">${this.escape(row.nation.slice(0, 3).toUpperCase())}</div>
+                    <div class="vehicle-art-name">${this.formatValue(row.rb_br)}</div>
+                </div>
+                <div class="vehicle-card-body">
+                    <h3>${this.displayName(row)}</h3>
+                    <div class="badge-row">
+                        <span>#${rank}</span>
+                        <span>BR ${this.formatValue(row.rb_br)}</span>
+                        <span>${this.escape(row.nation)}</span>
+                        <span>${this.escape(this.typeLabel(row))}</span>
+                        <span>Rank N/A</span>
+                        ${this.isPremium(row) ? "<span class=\"premium-badge\">Premium</span>" : ""}
+                    </div>
+                    <dl class="stat-grid">
+                        ${this.stat("Battles", row.rb_battles)}
+                        ${this.stat("Win rate", `${this.formatValue(row.rb_win_rate)}%`)}
+                        ${this.stat("Ground frags", this.estimatedGroundFrags(row))}
+                        ${this.stat("Deaths", this.estimatedDeaths(row))}
+                        ${this.stat("Frags / battle", row.rb_ground_frags_per_battle)}
+                        ${this.stat("Frags / death", row.rb_ground_frags_per_death)}
+                        ${this.stat("SL / game", row.rb_sl_rate)}
+                        ${this.stat("RP / game", row.rb_rp_rate)}
+                    </dl>
+                    ${lowSample ? "<p class=\"card-caveat\">Low sample: treat cautiously.</p>" : ""}
+                    <div class="card-actions">
+                        <button type="button" data-select="${this.escape(row.name)}">Details</button>
+                        <button type="button" data-compare="${this.escape(row.name)}">${compared ? "Remove" : "Compare"}</button>
+                        <button type="button" data-fav-toggle="${this.escape(row.name)}">${favorite ? "Unfavourite" : "Favourite"}</button>
+                        <button type="button" data-show-plot="${this.escape(row.name)}">Show plot</button>
+                    </div>
+                </div>
+            </article>
         `;
     }
 
@@ -313,7 +449,10 @@ export class GroundRbPanel {
         (this.byId("ground-premium") as HTMLSelectElement).value = preset === "premium" ? "premium" : "all";
         (this.byId("ground-min-battles") as HTMLInputElement).value = preset === "sample" ? "2000" : "1000";
         (this.byId("ground-search") as HTMLInputElement).value = "";
-        this.updateResults(preset === "played" ? "played" : preset === "frags" ? "frags" : "win");
+        this.currentSort = preset === "played" ? "played" : preset === "frags" ? "gkb" : "win";
+        (this.byId("ground-sort") as HTMLSelectElement).value = this.currentSort;
+        this.visibleCards = CARD_PAGE_SIZE;
+        this.updateResults();
     }
 
     private filters(): Filters {
@@ -450,8 +589,48 @@ export class GroundRbPanel {
         return `<label>${label}<select id="${id}" aria-label="${label}">${options.map(([value, text]) => `<option value="${value}">${text}</option>`).join("")}</select></label>`;
     }
 
+    private selectBare(id: string, options: Array<[string, string]>): string {
+        return `<select id="${id}" aria-label="Sort vehicles">${options.map(([value, text]) => `<option value="${value}">${text}</option>`).join("")}</select>`;
+    }
+
     private numberInput(id: string, label: string, min: string, max: string, step: string, value: string): string {
         return `<label>${label}<input id="${id}" aria-label="${label}" type="number" min="${min}" max="${max}" step="${step}" value="${value}"></label>`;
+    }
+
+    private stat(label: string, value: string): string {
+        return `<div><dt>${label}</dt><dd>${this.formatValue(value)}</dd></div>`;
+    }
+
+    private typeLabel(row: JoinedRow): string {
+        return row.cls === "Ground_vehicles" ? "Ground vehicle" : row.cls || "Type N/A";
+    }
+
+    private estimatedGroundFrags(row: JoinedRow): string {
+        const battles = this.toNumber(row.rb_battles);
+        const perBattle = this.toNumber(row.rb_ground_frags_per_battle);
+        const estimate = Math.round(battles * perBattle);
+        return estimate > 0 ? `${estimate}` : "N/A";
+    }
+
+    private estimatedDeaths(row: JoinedRow): string {
+        const frags = this.toNumber(this.estimatedGroundFrags(row));
+        const perDeath = this.toNumber(row.rb_ground_frags_per_death);
+        const estimate = perDeath > 0 ? Math.round(frags / perDeath) : 0;
+        return estimate > 0 ? `${estimate}` : "N/A";
+    }
+
+    private showLegacyPlot(name: string): void {
+        const row = this.rows.filter(item => item.name === name)[0];
+        if (!row) return;
+        const classSelect = document.getElementById("class-selection") as HTMLSelectElement;
+        const modeSelect = document.getElementById("mode-selection") as HTMLSelectElement;
+        const brRangeSelect = document.getElementById("br-range-selection") as HTMLSelectElement;
+        if (classSelect) classSelect.value = "Ground_vehicles";
+        if (modeSelect) modeSelect.value = "rb";
+        if (brRangeSelect) brRangeSelect.value = "1";
+        const target = document.getElementById("main-svg") || document.getElementById("content");
+        target?.scrollIntoView({ behavior: "smooth", block: "start" });
+        this.selectVehicle(row.name);
     }
 
     private byId(id: string): HTMLElement {


### PR DESCRIPTION
## User-facing changes
- Adds a Ground RB Card view next to the existing Table view, defaulting to cards.
- Adds a sort control for win rate, battles, ground frags/death, ground frags/battle, BR ascending/descending, and name A-Z.
- Renders responsive vehicle cards with vehicle name, nation, BR, result rank, class/type fallback, premium badge, battles, win rate, estimated ground frags, estimated deaths, ground frags per battle/death, SL/RP per game, and action buttons.
- Adds Details, Compare, Favourite, and Show plot actions on each card.
- Limits card rendering to the top 50 initially with a Show more button for performance.
- Keeps the existing results table, vehicle detail, comparison panel, source/license card, and legacy heatmap.

## Data/image source decision
- Inspected the prepared joined CSV and latest upstream wk CSV metadata. Current fields do not include image URLs, thumbnails, rank, or finer vehicle-type labels.
- The card gallery therefore uses a clean local placeholder panel with nation and BR, rather than scraping or hotlinking third-party images.
- The UI and README document that placeholders are intentional until a licensed/attributed image pipeline is available.
- Ground frags and deaths on cards are estimates derived from battles and per-battle/per-death rates because raw total kills/deaths are not available in the joined CSV.

## Testing performed
- `npm ci`
- `npm run prepare:data`
- `npm run build:pages`
- `npm run check:dist`
- Local static-server smoke test with headless Chrome confirmed Data ready, Card view/Table view controls, sort options, and rendered vehicle cards.

## Limitations
- Vehicle images are placeholders because no safe image source exists in the current data snapshots.
- Rank displays as N/A because no rank field exists in joined or wk data.
- Vehicle type is limited to the available class field, so Ground vehicles are shown with a generic Ground vehicle label.
- Show plot scrolls to the legacy heatmap area and preserves the existing plot workflow; it does not yet auto-select a specific heatmap square.