### PR TITLE
Add vehicle images to Ground RB cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Recommended Pages settings:
 | Build output directory | `dist` |
 | Node.js version | `20` from `.node-version` |
 
-The build command runs `prepare:data` first, then webpack in production mode, and emits the static app into `dist/`. The checked-in `wasm-utils/pkg/wasm_utils.js` package provides the data filtering helper, so Cloudflare Pages does not need a Rust toolchain. If a generated `.wasm` file is added to `wasm-utils/pkg/` later, webpack will copy it into the Pages artifact. The `wrangler.toml` file sets `pages_build_output_dir = "dist"` so Wrangler and Cloudflare Pages use the same output directory.
+The build command runs `prepare:data`, prepares the optional vehicle image manifest, then webpack in production mode, and emits the static app into `dist/`. The checked-in `wasm-utils/pkg/wasm_utils.js` package provides the data filtering helper, so Cloudflare Pages does not need a Rust toolchain. If a generated `.wasm` file is added to `wasm-utils/pkg/` later, webpack will copy it into the Pages artifact. The `wrangler.toml` file sets `pages_build_output_dir = "dist"` so Wrangler and Cloudflare Pages use the same output directory.
 
 Cloudflare Pages should deploy the generated `dist/` directory. Do not use the legacy `web` branch force-push workflow from the upstream project.
 
@@ -63,16 +63,20 @@ Cloudflare Pages should deploy the generated `dist/` directory. Do not use the l
 ```sh
 npm ci
 npm run prepare:data
+npm run prepare:images
 npm run build:production
 npm run check:dist
 ```
 
 `prepare:data` downloads upstream metadata from `ControlNet/wt-data-project.data`, writes `public/data/metadata.json`, and writes the latest joined CSV to `public/data/latest-joined.csv`. Webpack copies these files into `dist/data/`, so the deployed app can load `/data/metadata.json` and show an in-app data status.
 
+`prepare:images` builds `public/data/vehicle-images.json` from the official War Thunder Wiki Ground Vehicles page and its official CDN slot thumbnails. The manifest stores remote thumbnail URLs and source metadata; it does not download or redistribute image files. Set `WT_DISABLE_IMAGE_FETCH=1` before running the script if the wiki endpoint is down or you need an offline build. Missing or disabled image matches fall back to the local placeholder art in the card gallery.
+
 ### Cloudflare Pages Troubleshooting
 
 - Blank app shell: confirm `dist/index.html`, `dist/bundle.js`, `dist/index.css`, and `dist/config/params.json` are present and served with the expected content types.
 - Missing data status or Ground RB panel error: confirm `dist/data/metadata.json`, `dist/data/latest-joined.csv`, and `dist/data/source-info.json` exist. Run `npm run prepare:data` before building.
+- Missing vehicle card images: confirm `dist/data/vehicle-images.json` exists. Run `npm run prepare:images`, or set `WT_DISABLE_IMAGE_FETCH=1` to intentionally build with placeholders.
 - Custom domain issue: in Cloudflare DNS, `wt.mealspin.ca` should be a proxied `CNAME` to the Pages project domain, and the Pages project should list `wt.mealspin.ca` as an active custom domain.
 - Stale blank page after a fix: hard refresh the browser or purge Cloudflare cache for `bundle.js`.
 - Cloudflare build command: keep `npm run build:pages`; the npm `prebuild:pages` hook prepares data automatically.
@@ -87,7 +91,7 @@ This fork preserves upstream attribution and AGPL source availability:
 
 The app displays the prepared data date from `/data/metadata.json`. Thunderskill-derived data is sample-based, and joined data may contain imperfect vehicle matching, so low-sample rows should be treated as directional rather than definitive.
 
-The Ground RB card gallery uses generated placeholder panels for vehicles. The current upstream `joined` and `wk` CSV snapshots do not include safe vehicle image URLs, thumbnails, rank fields, or finer vehicle-type labels. If a future data-preparation pipeline adds licensed image URLs or local attributed assets, the card image area can be wired to that source.
+The Ground RB card gallery uses `public/data/vehicle-images.json` for best-effort vehicle thumbnails from the official War Thunder Wiki and `static.encyclopedia.warthunder.com` CDN. The manifest is generated from official wiki unit ids and stores remote URLs, source pages, source file names, match confidence, and attribution notes. The app only displays high-confidence matches. Missing, disabled, or failed images fall back to generated placeholder panels. The current upstream `joined` and `wk` CSV snapshots still do not include rank fields or finer vehicle-type labels.
 
 ## Features
 

--- a/index.css
+++ b/index.css
@@ -990,7 +990,7 @@ body:not(.dark-mode) .vehicle-card{
 }
 
 .vehicle-art{
-  min-height:118px;
+  aspect-ratio:16 / 9;
   position:relative;
   display:flex;
   align-items:flex-end;
@@ -1000,6 +1000,7 @@ body:not(.dark-mode) .vehicle-card{
     radial-gradient(circle at 28% 40%, rgba(125,159,180,.22), transparent 9rem),
     linear-gradient(135deg, rgba(50,65,76,.86), rgba(15,22,29,.92) 58%, rgba(28,38,26,.8));
   border-bottom:1px solid rgba(137,221,255,.12);
+  overflow:hidden;
 }
 
 .vehicle-art:before{
@@ -1012,10 +1013,87 @@ body:not(.dark-mode) .vehicle-card{
   transform:skewX(-12deg);
 }
 
+.vehicle-art img{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  object-position:center;
+  z-index:0;
+}
+
+.vehicle-art.has-image:before{
+  display:none;
+}
+
+.vehicle-art-placeholder{
+  position:absolute;
+  inset:0;
+  z-index:1;
+  display:flex;
+  align-items:flex-end;
+  justify-content:space-between;
+  padding:12px;
+}
+
+.vehicle-art.has-image .vehicle-art-placeholder{
+  opacity:0;
+}
+
+.vehicle-art.image-failed .vehicle-art-placeholder,
+.vehicle-art:not(.has-image) .vehicle-art-placeholder{
+  opacity:1;
+}
+
+.vehicle-art-overlay{
+  position:absolute;
+  inset:0;
+  z-index:1;
+  background:
+    linear-gradient(180deg, rgba(8,12,16,.08), rgba(8,12,16,.58) 72%, rgba(8,12,16,.86)),
+    linear-gradient(90deg, rgba(8,12,16,.36), rgba(8,12,16,.05) 48%, rgba(8,12,16,.42));
+  pointer-events:none;
+}
+
+.vehicle-art-badges{
+  position:absolute;
+  top:10px;
+  left:10px;
+  right:10px;
+  z-index:2;
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+}
+
+.vehicle-art-badges span{
+  border:1px solid rgba(232,244,255,.2);
+  border-radius:999px;
+  background:rgba(8,12,16,.66);
+  color:#f2f7fb;
+  font-size:.76rem;
+  font-weight:700;
+  padding:4px 8px;
+  backdrop-filter:blur(6px);
+}
+
+.vehicle-art-badges .premium-badge{
+  border-color:rgba(255,203,107,.45);
+  background:rgba(255,203,107,.2);
+  color:#ffe08a;
+}
+
+.vehicle-art.image-failed img,
+.vehicle-art.image-failed .vehicle-art-overlay,
+.vehicle-art.image-failed .vehicle-art-badges{
+  display:none;
+}
+
 .vehicle-art-mark,
 .vehicle-art-name{
   position:relative;
-  z-index:1;
+  z-index:2;
   border:1px solid rgba(232,244,255,.14);
   border-radius:999px;
   background:rgba(5,9,13,.55);

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "scripts": {
     "build": "webpack",
     "prepare:data": "node scripts/prepare-data.js",
-    "prebuild:pages": "npm run prepare:data",
+    "prepare:images": "node scripts/prepare-vehicle-images.mjs",
+    "prebuild:pages": "npm run prepare:data && npm run prepare:images",
     "build:pages": "webpack --config webpack.config.js --mode production",
-    "prebuild:production": "npm run prepare:data",
+    "prebuild:production": "npm run prepare:data && npm run prepare:images",
     "build:production": "webpack -c webpack.prod.js --mode production",
     "check:dist": "node scripts/check-dist.js",
     "watch": "webpack --watch",

--- a/public/data/vehicle-images.json
+++ b/public/data/vehicle-images.json
@@ -1,0 +1,10736 @@
+{
+  "generatedAt": "2026-07-06T20:10:43.089Z",
+  "source": {
+    "name": "War Thunder Wiki",
+    "groundPage": "https://wiki.warthunder.com/ground",
+    "cdn": "https://static.encyclopedia.warthunder.com",
+    "note": "Best-effort manifest built from official War Thunder Wiki unit ids and CDN slot thumbnails. Images are referenced remotely, not mirrored into this repository."
+  },
+  "images": {
+    "germ_panzerbefelhswagen_VI_P": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerbefelhswagen_vi_p.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_panzerbefelhswagen_vi_p",
+      "sourceFileTitle": "germ_panzerbefelhswagen_vi_p.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerbefelhswagen_vi_p.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_vsw_flak_41": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_vsw_flak_41.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_vsw_flak_41",
+      "sourceFileTitle": "germ_vsw_flak_41.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_vsw_flak_41.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_1941_57": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_1941_57.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_1941_57",
+      "sourceFileTitle": "ussr_t_34_1941_57.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_1941_57.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_85E": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_85e.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_85e",
+      "sourceFileTitle": "ussr_t_34_85e.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_85e.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_kv_1e": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_1e.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_kv_1e",
+      "sourceFileTitle": "ussr_kv_1e.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_1e.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_54_1947": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_54_1947.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_54_1947",
+      "sourceFileTitle": "ussr_t_54_1947.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_54_1947.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_kv_85": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_85.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_kv_85",
+      "sourceFileTitle": "ussr_kv_85.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_85.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_t_34_85_zis_53": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_34_85_zis_53.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_t_34_85_zis_53",
+      "sourceFileTitle": "sw_t_34_85_zis_53.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_34_85_zis_53.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_85_zis_53": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_85_zis_53.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_85_zis_53",
+      "sourceFileTitle": "ussr_t_34_85_zis_53.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_85_zis_53.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_VI_ausf_h1_tiger_west": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_h1_tiger_west.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_vi_ausf_h1_tiger_west",
+      "sourceFileTitle": "germ_pzkpfw_vi_ausf_h1_tiger_west.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_h1_tiger_west.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_object_906": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_906.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_object_906",
+      "sourceFileTitle": "ussr_object_906.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_906.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_sav_fm48": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_sav_fm48.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_sav_fm48",
+      "sourceFileTitle": "sw_sav_fm48.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_sav_fm48.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_VI_ausf_e_tiger": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_e_tiger.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_vi_ausf_e_tiger",
+      "sourceFileTitle": "germ_pzkpfw_vi_ausf_e_tiger.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_e_tiger.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_85_zis_53_v80": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_85_zis_53_v80.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_85_zis_53_v80",
+      "sourceFileTitle": "ussr_t_34_85_zis_53_v80.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_85_zis_53_v80.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_V_ausf_d_panther": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_v_ausf_d_panther.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_v_ausf_d_panther",
+      "sourceFileTitle": "germ_pzkpfw_v_ausf_d_panther.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_v_ausf_d_panther.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_t_34_1941": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_34_1941.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_t_34_1941",
+      "sourceFileTitle": "sw_t_34_1941.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_34_1941.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1a1_hc_usmc_sm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a1_hc_usmc_sm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1a1_hc_usmc_sm",
+      "sourceFileTitle": "us_m1a1_hc_usmc_sm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a1_hc_usmc_sm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_kv_1_zis_5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_1_zis_5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_kv_1_zis_5",
+      "sourceFileTitle": "ussr_kv_1_zis_5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_1_zis_5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_IV_ausf_C": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iv_ausf_c",
+      "sourceFileTitle": "germ_pzkpfw_iv_ausf_c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_VI_ausf_h1_tiger_east": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_h1_tiger_east.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_vi_ausf_h1_tiger_east",
+      "sourceFileTitle": "germ_pzkpfw_vi_ausf_h1_tiger_east.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_h1_tiger_east.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_80uk": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80uk.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_80uk",
+      "sourceFileTitle": "ussr_t_80uk.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80uk.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bt_5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bt_5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bt_5",
+      "sourceFileTitle": "ussr_bt_5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bt_5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_m_51": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_m_51.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_m_51",
+      "sourceFileTitle": "il_m_51.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_m_51.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_9_flak37": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_9_flak37.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_9_flak37",
+      "sourceFileTitle": "germ_sdkfz_9_flak37.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_9_flak37.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2k": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2k.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2k",
+      "sourceFileTitle": "germ_leopard_2k.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2k.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_panzerjager_panther": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerjager_panther.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_panzerjager_panther",
+      "sourceFileTitle": "germ_panzerjager_panther.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerjager_panther.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_panzerbefelhswagen_IV_ausf_J": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerbefelhswagen_iv_ausf_j.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_panzerbefelhswagen_iv_ausf_j",
+      "sourceFileTitle": "germ_panzerbefelhswagen_iv_ausf_j.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerbefelhswagen_iv_ausf_j.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_sherman_3_4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_sherman_3_4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_sherman_3_4",
+      "sourceFileTitle": "sw_sherman_3_4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_sherman_3_4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_4_chi_to_late": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_4_chi_to_late.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_4_chi_to_late",
+      "sourceFileTitle": "jp_type_4_chi_to_late.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_4_chi_to_late.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_4_chi_to": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_4_chi_to.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_4_chi_to",
+      "sourceFileTitle": "jp_type_4_chi_to.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_4_chi_to.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34E_STZ": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34e_stz.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34e_stz",
+      "sourceFileTitle": "ussr_t_34e_stz.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34e_stz.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_80ud": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80ud.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_80ud",
+      "sourceFileTitle": "ussr_t_80ud.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80ud.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_III_ausf_F": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_f.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iii_ausf_f",
+      "sourceFileTitle": "germ_pzkpfw_iii_ausf_f.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_f.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_80ue1_sm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80ue1_sm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_80ue1_sm",
+      "sourceFileTitle": "ussr_t_80ue1_sm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80ue1_sm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t20": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t20.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t20",
+      "sourceFileTitle": "us_t20.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t20.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_m24_chaffee": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m24_chaffee.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_m24_chaffee",
+      "sourceFileTitle": "jp_m24_chaffee.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m24_chaffee.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_btr_82at": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_btr_82at.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_btr_82at",
+      "sourceFileTitle": "ussr_btr_82at.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_btr_82at.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_VI_ausf_b_tiger_IIh_sla": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_b_tiger_iih_sla.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_vi_ausf_b_tiger_iih_sla",
+      "sourceFileTitle": "germ_pzkpfw_vi_ausf_b_tiger_iih_sla.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_b_tiger_iih_sla.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_I": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_i.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_i",
+      "sourceFileTitle": "germ_leopard_i.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_i.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_3_chi_nu_75cm_type_5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_3_chi_nu_75cm_type_5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_3_chi_nu_75cm_type_5",
+      "sourceFileTitle": "jp_type_3_chi_nu_75cm_type_5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_3_chi_nu_75cm_type_5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bt_7_1937": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bt_7_1937.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bt_7_1937",
+      "sourceFileTitle": "ussr_bt_7_1937.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bt_7_1937.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_panzerbefelhswagen_jagdpanther": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerbefelhswagen_jagdpanther.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_panzerbefelhswagen_jagdpanther",
+      "sourceFileTitle": "germ_panzerbefelhswagen_jagdpanther.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerbefelhswagen_jagdpanther.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_begleitpanzer_57": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_begleitpanzer_57.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_begleitpanzer_57",
+      "sourceFileTitle": "germ_begleitpanzer_57.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_begleitpanzer_57.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pvkv_II": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvkv_ii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pvkv_ii",
+      "sourceFileTitle": "sw_pvkv_ii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvkv_ii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_3_ka_chi": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_3_ka_chi.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_3_ka_chi",
+      "sourceFileTitle": "jp_type_3_ka_chi.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_3_ka_chi.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_VI_ausf_h1_tiger": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_h1_tiger.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_vi_ausf_h1_tiger",
+      "sourceFileTitle": "germ_pzkpfw_vi_ausf_h1_tiger.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_h1_tiger.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_IV_ausf_J": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_j.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iv_ausf_j",
+      "sourceFileTitle": "germ_pzkpfw_iv_ausf_j.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_j.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_72b3_2011": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72b3_2011.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_72b3_2011",
+      "sourceFileTitle": "ussr_t_72b3_2011.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72b3_2011.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m4a4_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m4a4_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m4a4_sherman",
+      "sourceFileTitle": "it_m4a4_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m4a4_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_lvkv_42": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_lvkv_42.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_lvkv_42",
+      "sourceFileTitle": "sw_lvkv_42.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_lvkv_42.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_100": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_100.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_100",
+      "sourceFileTitle": "ussr_t_34_100.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_100.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_is_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_is_1",
+      "sourceFileTitle": "ussr_is_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_85_d_5t": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_85_d_5t.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_85_d_5t",
+      "sourceFileTitle": "ussr_t_34_85_d_5t.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_85_d_5t.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_80bvm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80bvm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_80bvm",
+      "sourceFileTitle": "ussr_t_80bvm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80bvm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bmpt": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmpt.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bmpt",
+      "sourceFileTitle": "ussr_bmpt.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmpt.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t58": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t58.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t58",
+      "sourceFileTitle": "us_t58.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t58.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_m24_chaffee_dk": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_m24_chaffee_dk.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_m24_chaffee_dk",
+      "sourceFileTitle": "sw_m24_chaffee_dk.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_m24_chaffee_dk.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pzkpfw_IV_ausf_J": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pzkpfw_iv_ausf_j.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pzkpfw_iv_ausf_j",
+      "sourceFileTitle": "sw_pzkpfw_iv_ausf_j.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pzkpfw_iv_ausf_j.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_sherman_75_37": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_sherman_75_37.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_sherman_75_37",
+      "sourceFileTitle": "it_sherman_75_37.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_sherman_75_37.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t29": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t29.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t29",
+      "sourceFileTitle": "us_t29.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t29.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_57_1943": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_57_1943.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_57_1943",
+      "sourceFileTitle": "ussr_t_34_57_1943.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_57_1943.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_10m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_10m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_10m",
+      "sourceFileTitle": "ussr_t_10m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_10m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_zsu_57_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_57_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_zsu_57_2",
+      "sourceFileTitle": "ussr_zsu_57_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_57_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_zsu_29k": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_29k.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_zsu_29k",
+      "sourceFileTitle": "ussr_zsu_29k.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_29k.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_50_surbaisse": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_50_surbaisse.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_50_surbaisse",
+      "sourceFileTitle": "fr_amx_50_surbaisse.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_50_surbaisse.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_58": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_58.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_58",
+      "sourceFileTitle": "cn_type_58.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_58.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_80b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_80b",
+      "sourceFileTitle": "ussr_t_80b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_I_a1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_i_a1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_i_a1",
+      "sourceFileTitle": "germ_leopard_i_a1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_i_a1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m36": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m36.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m36",
+      "sourceFileTitle": "cn_m36.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m36.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m41_walker_bulldog": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m41_walker_bulldog.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m41_walker_bulldog",
+      "sourceFileTitle": "us_m41_walker_bulldog.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m41_walker_bulldog.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_kv_1s": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_1s.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_kv_1s",
+      "sourceFileTitle": "ussr_kv_1s.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_1s.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m6a1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m6a1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m6a1",
+      "sourceFileTitle": "us_m6a1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m6a1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzsflk40_sturer_emil": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzsflk40_sturer_emil.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzsflk40_sturer_emil",
+      "sourceFileTitle": "germ_pzsflk40_sturer_emil.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzsflk40_sturer_emil.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_t_34_85_d_5t": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_34_85_d_5t.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_t_34_85_d_5t",
+      "sourceFileTitle": "cn_t_34_85_d_5t.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_34_85_d_5t.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_72a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_72a",
+      "sourceFileTitle": "ussr_t_72a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzh_2000": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzh_2000.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzh_2000",
+      "sourceFileTitle": "germ_pzh_2000.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzh_2000.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_t_34_747": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_t_34_747.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_t_34_747",
+      "sourceFileTitle": "germ_t_34_747.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_t_34_747.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_1942": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_1942.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_1942",
+      "sourceFileTitle": "ussr_t_34_1942.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_1942.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_100p": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_100p.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_100p",
+      "sourceFileTitle": "ussr_su_100p.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_100p.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_is_7": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_7.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_is_7",
+      "sourceFileTitle": "ussr_is_7.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_7.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_merkava_mk_2d": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_2d.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_merkava_mk_2d",
+      "sourceFileTitle": "il_merkava_mk_2d.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_2d.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_IV_ausf_H": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_h.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iv_ausf_h",
+      "sourceFileTitle": "germ_pzkpfw_iv_ausf_h.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_h.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_vt_5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_vt_5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_vt_5",
+      "sourceFileTitle": "cn_vt_5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_vt_5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_a1a1_120": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_a1a1_120.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_a1a1_120",
+      "sourceFileTitle": "germ_leopard_a1a1_120.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_a1a1_120.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_kv_8": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_8.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_kv_8",
+      "sourceFileTitle": "ussr_kv_8.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_8.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m24_chaffee": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m24_chaffee.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m24_chaffee",
+      "sourceFileTitle": "it_m24_chaffee.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m24_chaffee.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_t_34_1942": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_34_1942.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_t_34_1942",
+      "sourceFileTitle": "cn_t_34_1942.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_34_1942.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_44_po": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_44_po.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_44_po",
+      "sourceFileTitle": "ussr_t_44_po.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_44_po.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_somua_sm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_somua_sm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_somua_sm",
+      "sourceFileTitle": "fr_somua_sm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_somua_sm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_90m_2020": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_90m_2020.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_90m_2020",
+      "sourceFileTitle": "ussr_t_90m_2020.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_90m_2020.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_kpz_70": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_kpz_70.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_kpz_70",
+      "sourceFileTitle": "germ_kpz_70.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_kpz_70.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_VI_ausf_b_tiger_IIh": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_b_tiger_iih.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_vi_ausf_b_tiger_iih",
+      "sourceFileTitle": "germ_pzkpfw_vi_ausf_b_tiger_iih.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_b_tiger_iih.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_72b_1989": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72b_1989.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_72b_1989",
+      "sourceFileTitle": "ussr_t_72b_1989.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72b_1989.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_9a35_m2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_9a35_m2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_9a35_m2",
+      "sourceFileTitle": "ussr_9a35_m2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_9a35_m2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_13_mk1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_13_mk1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_13_mk1",
+      "sourceFileTitle": "uk_a_13_mk1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_13_mk1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_35": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_35.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_35",
+      "sourceFileTitle": "ussr_t_35.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_35.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m18_hellcat": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m18_hellcat.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m18_hellcat",
+      "sourceFileTitle": "us_m18_hellcat.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m18_hellcat.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_72b3_arena": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72b3_arena.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_72b3_arena",
+      "sourceFileTitle": "ussr_t_72b3_arena.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72b3_arena.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pz_IV_L70": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pz_iv_l70.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pz_iv_l70",
+      "sourceFileTitle": "germ_pz_iv_l70.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pz_iv_l70.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_44": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_44.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_44",
+      "sourceFileTitle": "ussr_t_44.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_44.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t14": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t14.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t14",
+      "sourceFileTitle": "us_t14.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t14.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_xm_803": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm_803.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_xm_803",
+      "sourceFileTitle": "us_xm_803.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm_803.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_55a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_55a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_55a",
+      "sourceFileTitle": "ussr_t_55a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_55a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_m4a2_76w_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_m4a2_76w_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_m4a2_76w_sherman",
+      "sourceFileTitle": "ussr_m4a2_76w_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_m4a2_76w_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flakpanzer_IV_Ostwind": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_iv_ostwind.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flakpanzer_iv_ostwind",
+      "sourceFileTitle": "germ_flakpanzer_iv_ostwind.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_iv_ostwind.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_16_mcv_prot": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_16_mcv_prot.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_16_mcv_prot",
+      "sourceFileTitle": "jp_type_16_mcv_prot.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_16_mcv_prot.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_43m_turan_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_43m_turan_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_43m_turan_3",
+      "sourceFileTitle": "it_43m_turan_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_43m_turan_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_is_2_1944": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_2_1944.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_is_2_1944",
+      "sourceFileTitle": "ussr_is_2_1944.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_2_1944.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_72b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_72b",
+      "sourceFileTitle": "ussr_t_72b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_V_ausf_g_panther": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_v_ausf_g_panther.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_v_ausf_g_panther",
+      "sourceFileTitle": "germ_pzkpfw_v_ausf_g_panther.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_v_ausf_g_panther.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2a4m_can": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a4m_can.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2a4m_can",
+      "sourceFileTitle": "germ_leopard_2a4m_can.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a4m_can.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_5_na_to": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_5_na_to.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_5_na_to",
+      "sourceFileTitle": "jp_type_5_na_to.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_5_na_to.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_VI_ausf_h1_tiger_animal_version": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_h1_tiger_animal_version.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_vi_ausf_h1_tiger_animal_version",
+      "sourceFileTitle": "germ_pzkpfw_vi_ausf_h1_tiger_animal_version.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_h1_tiger_animal_version.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_spz_oerlikon_raketenautomat": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_spz_oerlikon_raketenautomat.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_spz_oerlikon_raketenautomat",
+      "sourceFileTitle": "germ_spz_oerlikon_raketenautomat.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_spz_oerlikon_raketenautomat.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_vt_4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_vt_4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_vt_4",
+      "sourceFileTitle": "cn_vt_4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_vt_4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a17_mk_1_tetrarch": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a17_mk_1_tetrarch.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a17_mk_1_tetrarch",
+      "sourceFileTitle": "uk_a17_mk_1_tetrarch.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a17_mk_1_tetrarch.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_44_100": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_44_100.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_44_100",
+      "sourceFileTitle": "ussr_t_44_100.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_44_100.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flakpz_I_Gepard": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpz_i_gepard.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flakpz_i_gepard",
+      "sourceFileTitle": "germ_flakpz_i_gepard.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpz_i_gepard.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_85_1943": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_85_1943.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_85_1943",
+      "sourceFileTitle": "ussr_su_85_1943.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_85_1943.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_IV_ausf_F2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_f2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iv_ausf_f2",
+      "sourceFileTitle": "germ_pzkpfw_iv_ausf_f2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_f2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_122b_plus": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_122b_plus.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_122b_plus",
+      "sourceFileTitle": "sw_strv_122b_plus.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_122b_plus.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_t_90s_bheeshma": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_t_90s_bheeshma.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_t_90s_bheeshma",
+      "sourceFileTitle": "uk_t_90s_bheeshma.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_t_90s_bheeshma.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t25": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t25.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t25",
+      "sourceFileTitle": "us_t25.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t25.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_80u": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80u.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_80u",
+      "sourceFileTitle": "ussr_t_80u.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80u.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m60a3_tts": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60a3_tts.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m60a3_tts",
+      "sourceFileTitle": "us_m60a3_tts.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60a3_tts.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m3_lee": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m3_lee.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m3_lee",
+      "sourceFileTitle": "us_m3_lee.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m3_lee.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a3e8_76w_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a3e8_76w_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a3e8_76w_sherman",
+      "sourceFileTitle": "us_m4a3e8_76w_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a3e8_76w_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_halftrack_m16": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_halftrack_m16.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_halftrack_m16",
+      "sourceFileTitle": "jp_halftrack_m16.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_halftrack_m16.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_90a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_90a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_90a",
+      "sourceFileTitle": "ussr_t_90a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_90a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a2_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a2_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a2_sherman",
+      "sourceFileTitle": "us_m4a2_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a2_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_btr_152d": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_btr_152d.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_btr_152d",
+      "sourceFileTitle": "ussr_btr_152d.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_btr_152d.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m36b2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m36b2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m36b2",
+      "sourceFileTitle": "us_m36b2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m36b2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_sherman_ic_firefly": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sherman_ic_firefly.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_sherman_ic_firefly",
+      "sourceFileTitle": "uk_sherman_ic_firefly.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sherman_ic_firefly.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_55_am": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_55_am.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_55_am",
+      "sourceFileTitle": "ussr_t_55_am.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_55_am.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_V_ausf_f_panther": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_v_ausf_f_panther.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_v_ausf_f_panther",
+      "sourceFileTitle": "germ_pzkpfw_v_ausf_f_panther.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_v_ausf_f_panther.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_pzkpfw_V": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_pzkpfw_v.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_pzkpfw_v",
+      "sourceFileTitle": "ussr_pzkpfw_v.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_pzkpfw_v.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_13_mk2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_13_mk2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_13_mk2",
+      "sourceFileTitle": "uk_a_13_mk2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_13_mk2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_nbfz_VI": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_nbfz_vi.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_nbfz_vi",
+      "sourceFileTitle": "germ_nbfz_vi.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_nbfz_vi.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_m39": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m39.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_m39",
+      "sourceFileTitle": "sw_strv_m39.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m39.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_kv_1_1942_fin": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_kv_1_1942_fin.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_kv_1_1942_fin",
+      "sourceFileTitle": "sw_kv_1_1942_fin.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_kv_1_1942_fin.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m2a4_1st_armor_div": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m2a4_1st_armor_div.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m2a4_1st_armor_div",
+      "sourceFileTitle": "us_m2a4_1st_armor_div.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m2a4_1st_armor_div.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_panther_II": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panther_ii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_panther_ii",
+      "sourceFileTitle": "germ_panther_ii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panther_ii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_41m_turan_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_41m_turan_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_41m_turan_2",
+      "sourceFileTitle": "it_41m_turan_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_41m_turan_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a3e2_76w_sherman_jumbo": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a3e2_76w_sherman_jumbo.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a3e2_76w_sherman_jumbo",
+      "sourceFileTitle": "us_m4a3e2_76w_sherman_jumbo.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a3e2_76w_sherman_jumbo.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_152": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_152.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_152",
+      "sourceFileTitle": "ussr_su_152.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_152.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bt_7_m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bt_7_m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bt_7_m",
+      "sourceFileTitle": "ussr_bt_7_m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bt_7_m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m36": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m36.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m36",
+      "sourceFileTitle": "us_m36.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m36.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pz_IV_L70_A": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pz_iv_l70_a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pz_iv_l70_a",
+      "sourceFileTitle": "germ_pz_iv_l70_a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pz_iv_l70_a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_wz_1001": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_wz_1001.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_wz_1001",
+      "sourceFileTitle": "cn_wz_1001.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_wz_1001.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_char_2c_bis": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_char_2c_bis.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_char_2c_bis",
+      "sourceFileTitle": "fr_char_2c_bis.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_char_2c_bis.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_VI_ausf_b_tiger_IIh_kwk46": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_b_tiger_iih_kwk46.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_vi_ausf_b_tiger_iih_kwk46",
+      "sourceFileTitle": "germ_pzkpfw_vi_ausf_b_tiger_iih_kwk46.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_b_tiger_iih_kwk46.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_lorraine_40t": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_lorraine_40t.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_lorraine_40t",
+      "sourceFileTitle": "fr_lorraine_40t.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_lorraine_40t.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_74": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_74.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_74",
+      "sourceFileTitle": "sw_strv_74.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_74.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzsfl_IVa_dickermax": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzsfl_iva_dickermax.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzsfl_iva_dickermax",
+      "sourceFileTitle": "germ_pzsfl_iva_dickermax.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzsfl_iva_dickermax.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_m42_delat_torn": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m42_delat_torn.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_m42_delat_torn",
+      "sourceFileTitle": "sw_strv_m42_delat_torn.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m42_delat_torn.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_pzkpfw_IV_ausf_G": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_pzkpfw_iv_ausf_g.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_pzkpfw_iv_ausf_g",
+      "sourceFileTitle": "it_pzkpfw_iv_ausf_g.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_pzkpfw_iv_ausf_g.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1a1_hc_usmc": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a1_hc_usmc.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1a1_hc_usmc",
+      "sourceFileTitle": "us_m1a1_hc_usmc.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a1_hc_usmc.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_kv_1_L_11": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_1_l_11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_kv_1_l_11",
+      "sourceFileTitle": "ussr_kv_1_l_11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_1_l_11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_64_b_1984": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_64_b_1984.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_64_b_1984",
+      "sourceFileTitle": "ussr_t_64_b_1984.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_64_b_1984.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_72av_turms": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72av_turms.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_72av_turms",
+      "sourceFileTitle": "ussr_t_72av_turms.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72av_turms.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m1a2t": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m1a2t.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m1a2t",
+      "sourceFileTitle": "cn_m1a2t.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m1a2t.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t1e1_90": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t1e1_90.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t1e1_90",
+      "sourceFileTitle": "us_t1e1_90.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t1e1_90.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t1e1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t1e1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t1e1",
+      "sourceFileTitle": "us_t1e1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t1e1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_87": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_87.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_87",
+      "sourceFileTitle": "jp_type_87.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_87.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_marder_clovis": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_marder_clovis.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_marder_clovis",
+      "sourceFileTitle": "germ_marder_clovis.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_marder_clovis.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_sabra_mk1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_sabra_mk1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_sabra_mk1",
+      "sourceFileTitle": "il_sabra_mk1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_sabra_mk1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_28": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_28.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_28",
+      "sourceFileTitle": "ussr_t_28.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_28.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_kv_1B_finland": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_kv_1b_finland.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_kv_1b_finland",
+      "sourceFileTitle": "germ_kv_1b_finland.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_kv_1b_finland.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_62m1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_62m1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_62m1",
+      "sourceFileTitle": "ussr_t_62m1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_62m1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_asu_85": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_asu_85.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_asu_85",
+      "sourceFileTitle": "ussr_asu_85.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_asu_85.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_kv_1_kwk_40": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_kv_1_kwk_40.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_kv_1_kwk_40",
+      "sourceFileTitle": "germ_kv_1_kwk_40.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_kv_1_kwk_40.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_waffentrager_krupp_steyr": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_waffentrager_krupp_steyr.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_waffentrager_krupp_steyr",
+      "sourceFileTitle": "germ_waffentrager_krupp_steyr.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_waffentrager_krupp_steyr.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_a_34_comet": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_a_34_comet.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_a_34_comet",
+      "sourceFileTitle": "sw_a_34_comet.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_a_34_comet.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_pt_76b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_pt_76b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_pt_76b",
+      "sourceFileTitle": "ussr_pt_76b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_pt_76b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_of_40_mk_2a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_of_40_mk_2a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_of_40_mk_2a",
+      "sourceFileTitle": "it_of_40_mk_2a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_of_40_mk_2a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_V_ausf_a_panther": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_v_ausf_a_panther.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_v_ausf_a_panther",
+      "sourceFileTitle": "germ_pzkpfw_v_ausf_a_panther.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_v_ausf_a_panther.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_charioteer_mk_7": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_charioteer_mk_7.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_charioteer_mk_7",
+      "sourceFileTitle": "sw_charioteer_mk_7.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_charioteer_mk_7.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_m38": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m38.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_m38",
+      "sourceFileTitle": "sw_strv_m38.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m38.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_stug_III_ausf_G": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_stug_iii_ausf_g.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_stug_iii_ausf_g",
+      "sourceFileTitle": "germ_stug_iii_ausf_g.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_stug_iii_ausf_g.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m60a1_rise_passive_era": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60a1_rise_passive_era.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m60a1_rise_passive_era",
+      "sourceFileTitle": "us_m60a1_rise_passive_era.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60a1_rise_passive_era.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4_sherman_calliope": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4_sherman_calliope.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4_sherman_calliope",
+      "sourceFileTitle": "us_m4_sherman_calliope.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4_sherman_calliope.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_jgdpz_IV_L48": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_jgdpz_iv_l48.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_jgdpz_iv_l48",
+      "sourceFileTitle": "germ_jgdpz_iv_l48.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_jgdpz_iv_l48.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_halftrack_m3_75mm_gmc": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_halftrack_m3_75mm_gmc.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_halftrack_m3_75mm_gmc",
+      "sourceFileTitle": "us_halftrack_m3_75mm_gmc.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_halftrack_m3_75mm_gmc.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_ram_90mm_aa": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ram_90mm_aa.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_ram_90mm_aa",
+      "sourceFileTitle": "uk_ram_90mm_aa.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ram_90mm_aa.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_85m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_85m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_85m",
+      "sourceFileTitle": "ussr_su_85m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_85m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_t_34_85_zis_53_no215": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_34_85_zis_53_no215.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_t_34_85_zis_53_no215",
+      "sourceFileTitle": "cn_t_34_85_zis_53_no215.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_34_85_zis_53_no215.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_28_1938": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_28_1938.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_28_1938",
+      "sourceFileTitle": "ussr_t_28_1938.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_28_1938.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_85_stp_s53": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_85_stp_s53.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_85_stp_s53",
+      "sourceFileTitle": "ussr_t_34_85_stp_s53.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_85_stp_s53.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_28E": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_28e.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_28e",
+      "sourceFileTitle": "ussr_t_28e.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_28e.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_50": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_50.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_50",
+      "sourceFileTitle": "fr_amx_50.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_50.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m8a1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m8a1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m8a1",
+      "sourceFileTitle": "us_m8a1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m8a1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m3a3_bradley": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m3a3_bradley.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m3a3_bradley",
+      "sourceFileTitle": "us_m3a3_bradley.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m3a3_bradley.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_t_28": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_28.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_t_28",
+      "sourceFileTitle": "sw_t_28.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_28.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_semovente_m41m_90": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m41m_90.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_semovente_m41m_90",
+      "sourceFileTitle": "it_semovente_m41m_90.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m41m_90.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_III_ausf_M": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iii_ausf_m",
+      "sourceFileTitle": "germ_pzkpfw_iii_ausf_m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pt_76b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pt_76b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pt_76b",
+      "sourceFileTitle": "sw_pt_76b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pt_76b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t30": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t30.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t30",
+      "sourceFileTitle": "us_t30.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t30.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_80ue1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80ue1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_80ue1",
+      "sourceFileTitle": "ussr_t_80ue1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80ue1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m26_pershing": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m26_pershing.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m26_pershing",
+      "sourceFileTitle": "fr_m26_pershing.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m26_pershing.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34E": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34e.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34e",
+      "sourceFileTitle": "ussr_t_34e.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34e.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1_abrams_kvt": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1_abrams_kvt.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1_abrams_kvt",
+      "sourceFileTitle": "us_m1_abrams_kvt.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1_abrams_kvt.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_oplot_t": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_oplot_t.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_oplot_t",
+      "sourceFileTitle": "cn_oplot_t.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_oplot_t.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flakpanzer_IV_Wirbelwind": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_iv_wirbelwind.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flakpanzer_iv_wirbelwind",
+      "sourceFileTitle": "germ_flakpanzer_iv_wirbelwind.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_iv_wirbelwind.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2a7v": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a7v.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2a7v",
+      "sourceFileTitle": "germ_leopard_2a7v.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a7v.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m26e1_pershing": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m26e1_pershing.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m26e1_pershing",
+      "sourceFileTitle": "us_m26e1_pershing.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m26e1_pershing.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_oplot_t": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_oplot_t.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_oplot_t",
+      "sourceFileTitle": "jp_oplot_t.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_oplot_t.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_panzerjager_tiger_P_ferdinand": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerjager_tiger_p_ferdinand.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_panzerjager_tiger_p_ferdinand",
+      "sourceFileTitle": "germ_panzerjager_tiger_p_ferdinand.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerjager_tiger_p_ferdinand.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_61": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_61.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_61",
+      "sourceFileTitle": "jp_type_61.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_61.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_kpz_t72m1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_kpz_t72m1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_kpz_t72m1",
+      "sourceFileTitle": "germ_kpz_t72m1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_kpz_t72m1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_sherman_vc_firefly": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sherman_vc_firefly.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_sherman_vc_firefly",
+      "sourceFileTitle": "uk_sherman_vc_firefly.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sherman_vc_firefly.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_sub_i_ii_20mm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_sub_i_ii_20mm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_sub_i_ii_20mm",
+      "sourceFileTitle": "jp_sub_i_ii_20mm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_sub_i_ii_20mm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_bt_42": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_bt_42.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_bt_42",
+      "sourceFileTitle": "sw_bt_42.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_bt_42.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_VI_ausf_b_tiger_IIp": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_b_tiger_iip.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_vi_ausf_b_tiger_iip",
+      "sourceFileTitle": "germ_pzkpfw_vi_ausf_b_tiger_iip.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_ausf_b_tiger_iip.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ztz_99": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_99.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ztz_99",
+      "sourceFileTitle": "cn_ztz_99.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_99.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_le_kpz_m41": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_le_kpz_m41.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_le_kpz_m41",
+      "sourceFileTitle": "germ_le_kpz_m41.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_le_kpz_m41.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m4a1_76w_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m4a1_76w_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m4a1_76w_sherman",
+      "sourceFileTitle": "cn_m4a1_76w_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m4a1_76w_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_17_pdr_m10_achilles_norfolk_yeomanry": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_17_pdr_m10_achilles_norfolk_yeomanry.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_17_pdr_m10_achilles_norfolk_yeomanry",
+      "sourceFileTitle": "uk_17_pdr_m10_achilles_norfolk_yeomanry.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_17_pdr_m10_achilles_norfolk_yeomanry.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_sk105_a2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_sk105_a2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_sk105_a2",
+      "sourceFileTitle": "fr_sk105_a2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_sk105_a2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2a6": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a6.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2a6",
+      "sourceFileTitle": "germ_leopard_2a6.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a6.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1a2_sep2_abrams": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a2_sep2_abrams.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1a2_sep2_abrams",
+      "sourceFileTitle": "us_m1a2_sep2_abrams.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a2_sep2_abrams.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_80um2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80um2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_80um2",
+      "sourceFileTitle": "ussr_t_80um2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80um2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bmd_4m2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmd_4m2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bmd_4m2",
+      "sourceFileTitle": "ussr_bmd_4m2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmd_4m2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_erprobungstrager_3_achs_turm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_erprobungstrager_3_achs_turm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_erprobungstrager_3_achs_turm",
+      "sourceFileTitle": "germ_erprobungstrager_3_achs_turm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_erprobungstrager_3_achs_turm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m46_patton": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m46_patton.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m46_patton",
+      "sourceFileTitle": "fr_m46_patton.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m46_patton.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_55_amd_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_55_amd_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_55_amd_1",
+      "sourceFileTitle": "ussr_t_55_amd_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_55_amd_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m42_duster": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m42_duster.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m42_duster",
+      "sourceFileTitle": "us_m42_duster.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m42_duster.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m24_chaffee": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m24_chaffee.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m24_chaffee",
+      "sourceFileTitle": "us_m24_chaffee.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m24_chaffee.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m18_hellcat": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m18_hellcat.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m18_hellcat",
+      "sourceFileTitle": "cn_m18_hellcat.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m18_hellcat.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t26e4_superpershing": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t26e4_superpershing.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t26e4_superpershing",
+      "sourceFileTitle": "us_t26e4_superpershing.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t26e4_superpershing.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m5a1_stuart": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m5a1_stuart.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m5a1_stuart",
+      "sourceFileTitle": "us_m5a1_stuart.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m5a1_stuart.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_mbt_70": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_mbt_70.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_mbt_70",
+      "sourceFileTitle": "us_mbt_70.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_mbt_70.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m4a4_sherman_1st_ptg": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m4a4_sherman_1st_ptg.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m4a4_sherman_1st_ptg",
+      "sourceFileTitle": "cn_m4a4_sherman_1st_ptg.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m4a4_sherman_1st_ptg.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_object_292": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_292.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_object_292",
+      "sourceFileTitle": "ussr_object_292.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_292.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bmpt_72": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmpt_72.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bmpt_72",
+      "sourceFileTitle": "ussr_bmpt_72.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmpt_72.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_radpanzer_90": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_radpanzer_90.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_radpanzer_90",
+      "sourceFileTitle": "germ_radpanzer_90.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_radpanzer_90.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a1_1942_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a1_1942_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a1_1942_sherman",
+      "sourceFileTitle": "us_m4a1_1942_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a1_1942_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_thyssen_henschel_tam_2ip": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_thyssen_henschel_tam_2ip.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_thyssen_henschel_tam_2ip",
+      "sourceFileTitle": "germ_thyssen_henschel_tam_2ip.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_thyssen_henschel_tam_2ip.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_sherman_II": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sherman_ii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_sherman_ii",
+      "sourceFileTitle": "uk_sherman_ii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sherman_ii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_vickers_mbt_mk_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vickers_mbt_mk_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_vickers_mbt_mk_1",
+      "sourceFileTitle": "uk_vickers_mbt_mk_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vickers_mbt_mk_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flakpanzer_IV_Kugelblitz": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_iv_kugelblitz.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flakpanzer_iv_kugelblitz",
+      "sourceFileTitle": "germ_flakpanzer_iv_kugelblitz.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_iv_kugelblitz.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_zsu_37_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_37_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_zsu_37_2",
+      "sourceFileTitle": "ussr_zsu_37_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_37_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_90b_sm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_90b_sm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_90b_sm",
+      "sourceFileTitle": "jp_type_90b_sm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_90b_sm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m4a1_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m4a1_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m4a1_sherman",
+      "sourceFileTitle": "fr_m4a1_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m4a1_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_asu_57": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_asu_57.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_asu_57",
+      "sourceFileTitle": "ussr_asu_57.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_asu_57.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m8_greyhound": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m8_greyhound.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m8_greyhound",
+      "sourceFileTitle": "cn_m8_greyhound.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m8_greyhound.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_cv_90120": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_cv_90120.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_cv_90120",
+      "sourceFileTitle": "sw_cv_90120.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_cv_90120.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_26_1940": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_26_1940.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_26_1940",
+      "sourceFileTitle": "ussr_t_26_1940.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_26_1940.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4_sherman",
+      "sourceFileTitle": "us_m4_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amd_35_sa35": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amd_35_sa35.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amd_35_sa35",
+      "sourceFileTitle": "fr_amd_35_sa35.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amd_35_sa35.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_IV_ausf_G": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_g.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iv_ausf_g",
+      "sourceFileTitle": "germ_pzkpfw_iv_ausf_g.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_g.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_vk_3002m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_vk_3002m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_vk_3002m",
+      "sourceFileTitle": "germ_vk_3002m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_vk_3002m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ztz_99_w": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_99_w.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ztz_99_w",
+      "sourceFileTitle": "cn_ztz_99_w.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_99_w.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_wz_305": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_wz_305.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_wz_305",
+      "sourceFileTitle": "cn_wz_305.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_wz_305.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_m4a3e8_76w_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m4a3e8_76w_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_m4a3e8_76w_sherman",
+      "sourceFileTitle": "jp_m4a3e8_76w_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m4a3e8_76w_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_chieftain_mk_10": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_chieftain_mk_10.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_chieftain_mk_10",
+      "sourceFileTitle": "uk_chieftain_mk_10.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_chieftain_mk_10.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_80": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_80",
+      "sourceFileTitle": "ussr_t_80.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_kv_7_u13": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_7_u13.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_kv_7_u13",
+      "sourceFileTitle": "ussr_kv_7_u13.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_7_u13.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flakpanzer_IV_Ostwind_2_net": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_iv_ostwind_2_net.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flakpanzer_iv_ostwind_2_net",
+      "sourceFileTitle": "germ_flakpanzer_iv_ostwind_2_net.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_iv_ostwind_2_net.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_38t_Marder_III_ausf_H": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_38t_marder_iii_ausf_h.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_38t_marder_iii_ausf_h",
+      "sourceFileTitle": "germ_pzkpfw_38t_marder_iii_ausf_h.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_38t_marder_iii_ausf_h.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_kv_220": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_220.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_kv_220",
+      "sourceFileTitle": "ussr_kv_220.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_220.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_m31": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m31.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_m31",
+      "sourceFileTitle": "sw_strv_m31.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m31.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_1941_l_11": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_1941_l_11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_1941_l_11",
+      "sourceFileTitle": "ussr_t_34_1941_l_11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_1941_l_11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv121b_christian2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv121b_christian2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv121b_christian2",
+      "sourceFileTitle": "sw_strv121b_christian2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv121b_christian2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a1_76w_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a1_76w_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a1_76w_sherman",
+      "sourceFileTitle": "us_m4a1_76w_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a1_76w_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_marder_df_105": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_marder_df_105.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_marder_df_105",
+      "sourceFileTitle": "germ_marder_df_105.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_marder_df_105.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_30": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_30",
+      "sourceFileTitle": "fr_amx_30.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pbv_501": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pbv_501.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pbv_501",
+      "sourceFileTitle": "sw_pbv_501.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pbv_501.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_al_khalid_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_al_khalid_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_al_khalid_1",
+      "sourceFileTitle": "cn_al_khalid_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_al_khalid_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ztz_99a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_99a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ztz_99a",
+      "sourceFileTitle": "cn_ztz_99a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_99a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_zis_30": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zis_30.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_zis_30",
+      "sourceFileTitle": "ussr_zis_30.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zis_30.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_62": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_62.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_62",
+      "sourceFileTitle": "ussr_t_62.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_62.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_cv_90105_tml": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_cv_90105_tml.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_cv_90105_tml",
+      "sourceFileTitle": "sw_cv_90105_tml.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_cv_90105_tml.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_marder_df_105": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_marder_df_105.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_marder_df_105",
+      "sourceFileTitle": "fr_marder_df_105.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_marder_df_105.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ztz_96b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_96b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ztz_96b",
+      "sourceFileTitle": "cn_ztz_96b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_96b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_1a5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_1a5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_1a5",
+      "sourceFileTitle": "germ_leopard_1a5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_1a5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_landsverk_ush_405": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_landsverk_ush_405.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_landsverk_ush_405",
+      "sourceFileTitle": "sw_landsverk_ush_405.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_landsverk_ush_405.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_74_c": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_74_c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_74_c",
+      "sourceFileTitle": "jp_type_74_c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_74_c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m6a2e1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m6a2e1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m6a2e1",
+      "sourceFileTitle": "us_m6a2e1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m6a2e1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m4a4_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m4a4_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m4a4_sherman",
+      "sourceFileTitle": "fr_m4a4_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m4a4_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_90b_camo": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_90b_camo.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_90b_camo",
+      "sourceFileTitle": "jp_type_90b_camo.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_90b_camo.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pvkv_m43_1946": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvkv_m43_1946.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pvkv_m43_1946",
+      "sourceFileTitle": "sw_pvkv_m43_1946.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvkv_m43_1946.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_st_a2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_st_a2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_st_a2",
+      "sourceFileTitle": "jp_st_a2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_st_a2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m247": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m247.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m247",
+      "sourceFileTitle": "us_m247.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m247.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_lvt_a_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_lvt_a_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_lvt_a_1",
+      "sourceFileTitle": "us_lvt_a_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_lvt_a_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flakpanzer_V_Coelian": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_v_coelian.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flakpanzer_v_coelian",
+      "sourceFileTitle": "germ_flakpanzer_v_coelian.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_v_coelian.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_bkan_1c": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_bkan_1c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_bkan_1c",
+      "sourceFileTitle": "sw_bkan_1c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_bkan_1c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_43_black_prince": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_43_black_prince.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_43_black_prince",
+      "sourceFileTitle": "uk_a_43_black_prince.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_43_black_prince.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_object_435": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_435.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_object_435",
+      "sourceFileTitle": "ussr_object_435.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_435.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_lav_ad": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_lav_ad.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_lav_ad",
+      "sourceFileTitle": "us_lav_ad.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_lav_ad.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_tor_m1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_tor_m1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_tor_m1",
+      "sourceFileTitle": "cn_tor_m1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_tor_m1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_centurion_shot_kal_d": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_centurion_shot_kal_d.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_centurion_shot_kal_d",
+      "sourceFileTitle": "il_centurion_shot_kal_d.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_centurion_shot_kal_d.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_mkpz_m48a2c": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_mkpz_m48a2c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_mkpz_m48a2c",
+      "sourceFileTitle": "germ_mkpz_m48a2c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_mkpz_m48a2c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_ikv_73": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_ikv_73.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_ikv_73",
+      "sourceFileTitle": "sw_ikv_73.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_ikv_73.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_3_chi_nu": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_3_chi_nu.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_3_chi_nu",
+      "sourceFileTitle": "jp_type_3_chi_nu.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_3_chi_nu.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_jgdpz_38t": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_jgdpz_38t.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_jgdpz_38t",
+      "sourceFileTitle": "germ_jgdpz_38t.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_jgdpz_38t.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_1941": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_1941.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_1941",
+      "sourceFileTitle": "ussr_t_34_1941.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_1941.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_ikv_103": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_ikv_103.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_ikv_103",
+      "sourceFileTitle": "sw_ikv_103.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_ikv_103.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_m42_eh": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m42_eh.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_m42_eh",
+      "sourceFileTitle": "sw_strv_m42_eh.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m42_eh.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_IV_ausf_F": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_f.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iv_ausf_f",
+      "sourceFileTitle": "germ_pzkpfw_iv_ausf_f.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_f.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_p_26_40": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_p_26_40.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_p_26_40",
+      "sourceFileTitle": "it_p_26_40.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_p_26_40.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_72b3_arena_m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72b3_arena_m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_72b3_arena_m",
+      "sourceFileTitle": "ussr_t_72b3_arena_m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72b3_arena_m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_is_1_kit_3rank": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_1_kit_3rank.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_is_1_kit_3rank",
+      "sourceFileTitle": "ussr_is_1_kit_3rank.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_1_kit_3rank.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_tgdgb_m40_lv": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_tgdgb_m40_lv.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_tgdgb_m40_lv",
+      "sourceFileTitle": "sw_tgdgb_m40_lv.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_tgdgb_m40_lv.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_74": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_74.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_74",
+      "sourceFileTitle": "jp_type_74.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_74.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flakpz_1a2_Gepard": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpz_1a2_gepard.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flakpz_1a2_gepard",
+      "sourceFileTitle": "germ_flakpz_1a2_gepard.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpz_1a2_gepard.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_leopard_2a4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_leopard_2a4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_leopard_2a4",
+      "sourceFileTitle": "it_leopard_2a4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_leopard_2a4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_5_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_5_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_5_1",
+      "sourceFileTitle": "ussr_su_5_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_5_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_xm246": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm246.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_xm246",
+      "sourceFileTitle": "us_xm246.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm246.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_mk1_grant": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_mk1_grant.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_mk1_grant",
+      "sourceFileTitle": "us_mk1_grant.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_mk1_grant.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_t_80u": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_80u.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_t_80u",
+      "sourceFileTitle": "sw_t_80u.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_80u.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m18_hellcat_black_cat": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m18_hellcat_black_cat.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m18_hellcat_black_cat",
+      "sourceFileTitle": "us_m18_hellcat_black_cat.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m18_hellcat_black_cat.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_mars_15": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_mars_15.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_mars_15",
+      "sourceFileTitle": "fr_mars_15.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_mars_15.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_btr_3e1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_btr_3e1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_btr_3e1",
+      "sourceFileTitle": "jp_btr_3e1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_btr_3e1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_38t_ausf_A": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_38t_ausf_a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_38t_ausf_a",
+      "sourceFileTitle": "germ_pzkpfw_38t_ausf_a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_38t_ausf_a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_kv_2_754r": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_kv_2_754r.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_kv_2_754r",
+      "sourceFileTitle": "germ_kv_2_754r.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_kv_2_754r.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_as_90_mk_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_as_90_mk_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_as_90_mk_2",
+      "sourceFileTitle": "uk_as_90_mk_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_as_90_mk_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_elc_901": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_elc_901.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_elc_901",
+      "sourceFileTitle": "fr_amx_elc_901.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_elc_901.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_smk": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_smk.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_smk",
+      "sourceFileTitle": "ussr_smk.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_smk.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_st_a1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_st_a1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_st_a1",
+      "sourceFileTitle": "jp_st_a1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_st_a1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_stingray": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_stingray.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_stingray",
+      "sourceFileTitle": "us_stingray.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_stingray.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_64a_1971": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_64a_1971.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_64a_1971",
+      "sourceFileTitle": "ussr_t_64a_1971.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_64a_1971.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_leopard_2a6nl": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_leopard_2a6nl.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_leopard_2a6nl",
+      "sourceFileTitle": "sw_leopard_2a6nl.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_leopard_2a6nl.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_m_51_w": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_m_51_w.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_m_51_w",
+      "sourceFileTitle": "il_m_51_w.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_m_51_w.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a3e2_sherman_jumbo_cobra_king": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a3e2_sherman_jumbo_cobra_king.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a3e2_sherman_jumbo_cobra_king",
+      "sourceFileTitle": "us_m4a3e2_sherman_jumbo_cobra_king.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a3e2_sherman_jumbo_cobra_king.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bmp_2m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmp_2m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bmp_2m",
+      "sourceFileTitle": "ussr_bmp_2m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmp_2m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_97_chi_ha": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_97_chi_ha.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_97_chi_ha",
+      "sourceFileTitle": "jp_type_97_chi_ha.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_97_chi_ha.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_panzerjager_tiger_P_elefant": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerjager_tiger_p_elefant.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_panzerjager_tiger_p_elefant",
+      "sourceFileTitle": "germ_panzerjager_tiger_p_elefant.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerjager_tiger_p_elefant.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a30_challenger": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a30_challenger.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a30_challenger",
+      "sourceFileTitle": "uk_a30_challenger.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a30_challenger.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ztz_96": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_96.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ztz_96",
+      "sourceFileTitle": "cn_ztz_96.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_96.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_arl_44_acl1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_arl_44_acl1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_arl_44_acl1",
+      "sourceFileTitle": "fr_arl_44_acl1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_arl_44_acl1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_74_red_star": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_74_red_star.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_74_red_star",
+      "sourceFileTitle": "jp_type_74_red_star.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_74_red_star.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_rdf_lt": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_rdf_lt.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_rdf_lt",
+      "sourceFileTitle": "us_rdf_lt.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_rdf_lt.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_vcc_80_hitfist_60": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_vcc_80_hitfist_60.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_vcc_80_hitfist_60",
+      "sourceFileTitle": "it_vcc_80_hitfist_60.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_vcc_80_hitfist_60.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_thyssen_henschel_tam": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_thyssen_henschel_tam.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_thyssen_henschel_tam",
+      "sourceFileTitle": "germ_thyssen_henschel_tam.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_thyssen_henschel_tam.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_zts_63_1980": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_zts_63_1980.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_zts_63_1980",
+      "sourceFileTitle": "cn_zts_63_1980.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_zts_63_1980.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_3_ho_ni_I": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_3_ho_ni_i.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_3_ho_ni_i",
+      "sourceFileTitle": "jp_type_3_ho_ni_i.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_3_ho_ni_i.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m15_42_contraereo": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m15_42_contraereo.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m15_42_contraereo",
+      "sourceFileTitle": "it_m15_42_contraereo.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m15_42_contraereo.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_93": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_93.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_93",
+      "sourceFileTitle": "jp_type_93.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_93.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m4a3_105_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m4a3_105_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m4a3_105_sherman",
+      "sourceFileTitle": "fr_m4a3_105_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m4a3_105_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m8_scott": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m8_scott.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m8_scott",
+      "sourceFileTitle": "cn_m8_scott.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m8_scott.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_m53_59": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_m53_59.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_m53_59",
+      "sourceFileTitle": "ussr_m53_59.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_m53_59.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_13_90": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_90.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_13_90",
+      "sourceFileTitle": "fr_amx_13_90.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_90.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_stug_III_ausf_G": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_stug_iii_ausf_g.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_stug_iii_ausf_g",
+      "sourceFileTitle": "it_stug_iii_ausf_g.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_stug_iii_ausf_g.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t92": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t92.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t92",
+      "sourceFileTitle": "us_t92.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t92.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_90": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_90.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_90",
+      "sourceFileTitle": "jp_type_90.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_90.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_m109": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_m109.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_m109",
+      "sourceFileTitle": "il_m109.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_m109.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m26a1_pershing": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m26a1_pershing.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m26a1_pershing",
+      "sourceFileTitle": "it_m26a1_pershing.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m26a1_pershing.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_85_zis_53_kit_3rank": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_85_zis_53_kit_3rank.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_85_zis_53_kit_3rank",
+      "sourceFileTitle": "ussr_t_34_85_zis_53_kit_3rank.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_85_zis_53_kit_3rank.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_chieftain_900": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_chieftain_900.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_chieftain_900",
+      "sourceFileTitle": "uk_chieftain_900.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_chieftain_900.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_t_72m1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_72m1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_t_72m1",
+      "sourceFileTitle": "sw_t_72m1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_72m1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_t_26_1940": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_26_1940.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_t_26_1940",
+      "sourceFileTitle": "cn_t_26_1940.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_26_1940.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a2_76w_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a2_76w_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a2_76w_sherman",
+      "sourceFileTitle": "us_m4a2_76w_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a2_76w_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_ttd": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ttd.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_ttd",
+      "sourceFileTitle": "uk_ttd.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ttd.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_of_40_mtca": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_of_40_mtca.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_of_40_mtca",
+      "sourceFileTitle": "it_of_40_mtca.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_of_40_mtca.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_mkpz_m48a2ga2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_mkpz_m48a2ga2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_mkpz_m48a2ga2",
+      "sourceFileTitle": "germ_mkpz_m48a2ga2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_mkpz_m48a2ga2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_44_122": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_44_122.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_44_122",
+      "sourceFileTitle": "ussr_t_44_122.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_44_122.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_c1_ariete_preserie": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_c1_ariete_preserie.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_c1_ariete_preserie",
+      "sourceFileTitle": "it_c1_ariete_preserie.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_c1_ariete_preserie.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ztl_11": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztl_11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ztl_11",
+      "sourceFileTitle": "cn_ztl_11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztl_11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2pl": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2pl.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2pl",
+      "sourceFileTitle": "germ_leopard_2pl.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2pl.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_V_ersatz_m10": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_v_ersatz_m10.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_v_ersatz_m10",
+      "sourceFileTitle": "germ_pzkpfw_v_ersatz_m10.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_v_ersatz_m10.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_centauro_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_centauro_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_centauro_2",
+      "sourceFileTitle": "it_centauro_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_centauro_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_64": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_64.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_64",
+      "sourceFileTitle": "cn_type_64.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_64.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_panzerjager_nashorn": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerjager_nashorn.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_panzerjager_nashorn",
+      "sourceFileTitle": "germ_panzerjager_nashorn.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerjager_nashorn.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_101": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_101.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_101",
+      "sourceFileTitle": "sw_strv_101.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_101.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m24_chaffee": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m24_chaffee.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m24_chaffee",
+      "sourceFileTitle": "cn_m24_chaffee.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m24_chaffee.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_merkava_mk_2b_early": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_2b_early.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_merkava_mk_2b_early",
+      "sourceFileTitle": "il_merkava_mk_2b_early.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_2b_early.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_isu_122s": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_isu_122s.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_isu_122s",
+      "sourceFileTitle": "ussr_isu_122s.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_isu_122s.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m46_patton_73_armor_bat": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m46_patton_73_armor_bat.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m46_patton_73_armor_bat",
+      "sourceFileTitle": "us_m46_patton_73_armor_bat.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m46_patton_73_armor_bat.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m2a4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m2a4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m2a4",
+      "sourceFileTitle": "us_m2a4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m2a4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flakpanzer_IV_Ostwind_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_iv_ostwind_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flakpanzer_iv_ostwind_2",
+      "sourceFileTitle": "germ_flakpanzer_iv_ostwind_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_iv_ostwind_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_38t_Marder_III": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_38t_marder_iii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_38t_marder_iii",
+      "sourceFileTitle": "germ_pzkpfw_38t_marder_iii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_38t_marder_iii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a30_sp_avenger": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a30_sp_avenger.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a30_sp_avenger",
+      "sourceFileTitle": "uk_a30_sp_avenger.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a30_sp_avenger.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_ac4_thunderbolt": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ac4_thunderbolt.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_ac4_thunderbolt",
+      "sourceFileTitle": "uk_ac4_thunderbolt.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ac4_thunderbolt.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_30_b2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_b2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_30_b2",
+      "sourceFileTitle": "fr_amx_30_b2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_b2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t54e1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t54e1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t54e1",
+      "sourceFileTitle": "us_t54e1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t54e1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_2s1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_2s1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_2s1",
+      "sourceFileTitle": "it_2s1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_2s1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_44m_zrinyi_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_44m_zrinyi_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_44m_zrinyi_1",
+      "sourceFileTitle": "it_44m_zrinyi_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_44m_zrinyi_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m19": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m19.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m19",
+      "sourceFileTitle": "us_m19.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m19.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m55": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m55.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m55",
+      "sourceFileTitle": "it_m55.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m55.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_3_idf": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_3_idf.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_3_idf",
+      "sourceFileTitle": "il_magach_3_idf.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_3_idf.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_90b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_90b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_90b",
+      "sourceFileTitle": "jp_type_90b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_90b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_2s19_m1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s19_m1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_2s19_m1",
+      "sourceFileTitle": "ussr_2s19_m1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s19_m1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_tcm_20": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_tcm_20.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_tcm_20",
+      "sourceFileTitle": "il_tcm_20.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_tcm_20.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_is_2_1943": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_2_1943.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_is_2_1943",
+      "sourceFileTitle": "ussr_is_2_1943.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_2_1943.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ztz_88b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_88b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ztz_88b",
+      "sourceFileTitle": "cn_ztz_88b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_88b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_m41_walker_bulldog": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m41_walker_bulldog.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_m41_walker_bulldog",
+      "sourceFileTitle": "jp_m41_walker_bulldog.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m41_walker_bulldog.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ztz_88a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_88a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ztz_88a",
+      "sourceFileTitle": "cn_ztz_88a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_88a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pvkv_m43_1963": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvkv_m43_1963.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pvkv_m43_1963",
+      "sourceFileTitle": "sw_pvkv_m43_1963.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvkv_m43_1963.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a2_1944_germ": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a2_1944_germ.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a2_1944_germ",
+      "sourceFileTitle": "us_m4a2_1944_germ.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a2_1944_germ.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4_t26": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4_t26.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4_t26",
+      "sourceFileTitle": "us_m4_t26.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4_t26.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_mbt2000": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_mbt2000.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_mbt2000",
+      "sourceFileTitle": "cn_mbt2000.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_mbt2000.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_pzkpfw_VI_ausf_e_tiger": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_pzkpfw_vi_ausf_e_tiger.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_pzkpfw_vi_ausf_e_tiger",
+      "sourceFileTitle": "it_pzkpfw_vi_ausf_e_tiger.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_pzkpfw_vi_ausf_e_tiger.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_panhard_ebr_1954": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_panhard_ebr_1954.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_panhard_ebr_1954",
+      "sourceFileTitle": "fr_panhard_ebr_1954.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_panhard_ebr_1954.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_III_ausf_E": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_e.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iii_ausf_e",
+      "sourceFileTitle": "germ_pzkpfw_iii_ausf_e.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_e.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m50_ontos": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m50_ontos.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m50_ontos",
+      "sourceFileTitle": "us_m50_ontos.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m50_ontos.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_III_ausf_J_L42": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_j_l42.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iii_ausf_j_l42",
+      "sourceFileTitle": "germ_pzkpfw_iii_ausf_j_l42.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_j_l42.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_t_80ud_478be": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_80ud_478be.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_t_80ud_478be",
+      "sourceFileTitle": "cn_t_80ud_478be.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_80ud_478be.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_leopard_1a2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_leopard_1a2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_leopard_1a2",
+      "sourceFileTitle": "it_leopard_1a2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_leopard_1a2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_sav_m43_1946": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_sav_m43_1946.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_sav_m43_1946",
+      "sourceFileTitle": "sw_sav_m43_1946.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_sav_m43_1946.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_ikv_91": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_ikv_91.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_ikv_91",
+      "sourceFileTitle": "sw_ikv_91.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_ikv_91.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_st_a3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_st_a3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_st_a3",
+      "sourceFileTitle": "jp_st_a3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_st_a3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_lvt_a1_m24": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_lvt_a1_m24.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_lvt_a1_m24",
+      "sourceFileTitle": "us_lvt_a1_m24.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_lvt_a1_m24.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m3_stuart": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m3_stuart.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m3_stuart",
+      "sourceFileTitle": "us_m3_stuart.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m3_stuart.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_zsu_23_4m4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_23_4m4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_zsu_23_4m4",
+      "sourceFileTitle": "ussr_zsu_23_4m4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_23_4m4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2a4_pzbtl_123": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a4_pzbtl_123.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2a4_pzbtl_123",
+      "sourceFileTitle": "germ_leopard_2a4_pzbtl_123.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a4_pzbtl_123.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sturmpanzer_IV_brummbar": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sturmpanzer_iv_brummbar.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sturmpanzer_iv_brummbar",
+      "sourceFileTitle": "germ_sturmpanzer_iv_brummbar.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sturmpanzer_iv_brummbar.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_stug_III_ausf_F": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_stug_iii_ausf_f.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_stug_iii_ausf_f",
+      "sourceFileTitle": "germ_stug_iii_ausf_f.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_stug_iii_ausf_f.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_2s38": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s38.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_2s38",
+      "sourceFileTitle": "ussr_2s38.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s38.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_zsu_57_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_zsu_57_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_zsu_57_2",
+      "sourceFileTitle": "it_zsu_57_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_zsu_57_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_arl_44": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_arl_44.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_arl_44",
+      "sourceFileTitle": "fr_arl_44.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_arl_44.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_btr_80a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_btr_80a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_btr_80a",
+      "sourceFileTitle": "ussr_btr_80a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_btr_80a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1a2_abrams": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a2_abrams.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1a2_abrams",
+      "sourceFileTitle": "us_m1a2_abrams.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a2_abrams.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_m41_s2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m41_s2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_m41_s2",
+      "sourceFileTitle": "sw_strv_m41_s2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m41_s2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m26_t99": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m26_t99.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m26_t99",
+      "sourceFileTitle": "us_m26_t99.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m26_t99.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_mkpz_super_m48": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_mkpz_super_m48.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_mkpz_super_m48",
+      "sourceFileTitle": "germ_mkpz_super_m48.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_mkpz_super_m48.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_2s25m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s25m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_2s25m",
+      "sourceFileTitle": "ussr_2s25m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s25m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_kv_2_1939": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_2_1939.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_kv_2_1939",
+      "sourceFileTitle": "ussr_kv_2_1939.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_2_1939.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_12_mk_2_matilda_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_12_mk_2_matilda_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_12_mk_2_matilda_2",
+      "sourceFileTitle": "uk_a_12_mk_2_matilda_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_12_mk_2_matilda_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_centurion_mk_5_shot": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_centurion_mk_5_shot.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_centurion_mk_5_shot",
+      "sourceFileTitle": "il_centurion_mk_5_shot.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_centurion_mk_5_shot.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_is_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_is_3",
+      "sourceFileTitle": "ussr_is_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2a4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2a4",
+      "sourceFileTitle": "germ_leopard_2a4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2a5_pso": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a5_pso.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2a5_pso",
+      "sourceFileTitle": "germ_leopard_2a5_pso.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a5_pso.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_fv107_scimitar": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv107_scimitar.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_fv107_scimitar",
+      "sourceFileTitle": "uk_fv107_scimitar.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv107_scimitar.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_kanonenjagdpanzer": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_kanonenjagdpanzer.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_kanonenjagdpanzer",
+      "sourceFileTitle": "germ_kanonenjagdpanzer.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_kanonenjagdpanzer.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_aml_90": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_aml_90.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_aml_90",
+      "sourceFileTitle": "il_aml_90.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_aml_90.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ztz_96a_prot": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_96a_prot.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ztz_96a_prot",
+      "sourceFileTitle": "cn_ztz_96a_prot.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_96a_prot.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_30_1972": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_1972.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_30_1972",
+      "sourceFileTitle": "fr_amx_30_1972.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_1972.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_as_42_47": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_as_42_47.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_as_42_47",
+      "sourceFileTitle": "it_as_42_47.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_as_42_47.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_challenger_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_challenger_1",
+      "sourceFileTitle": "uk_challenger_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_30_dca": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_dca.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_30_dca",
+      "sourceFileTitle": "fr_amx_30_dca.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_dca.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1128_mgs": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1128_mgs.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1128_mgs",
+      "sourceFileTitle": "us_m1128_mgs.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1128_mgs.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_conqueror_mk_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_conqueror_mk_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_conqueror_mk_2",
+      "sourceFileTitle": "uk_conqueror_mk_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_conqueror_mk_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_fv4202": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv4202.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_fv4202",
+      "sourceFileTitle": "uk_fv4202.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv4202.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_m44": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_m44.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_m44",
+      "sourceFileTitle": "germ_m44.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_m44.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_concept3_ngac": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_concept3_ngac.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_concept3_ngac",
+      "sourceFileTitle": "uk_concept3_ngac.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_concept3_ngac.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_234_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_234_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_234_2",
+      "sourceFileTitle": "germ_sdkfz_234_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_234_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m10": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m10.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m10",
+      "sourceFileTitle": "fr_m10.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m10.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_tkx_prot": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_tkx_prot.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_tkx_prot",
+      "sourceFileTitle": "jp_tkx_prot.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_tkx_prot.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t34": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t34.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t34",
+      "sourceFileTitle": "us_t34.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t34.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m60_120s": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60_120s.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m60_120s",
+      "sourceFileTitle": "us_m60_120s.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60_120s.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_81": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_81.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_81",
+      "sourceFileTitle": "sw_strv_81.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_81.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_veak_40": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_veak_40.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_veak_40",
+      "sourceFileTitle": "sw_veak_40.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_veak_40.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_landsverk_ush_204_gk": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_landsverk_ush_204_gk.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_landsverk_ush_204_gk",
+      "sourceFileTitle": "sw_landsverk_ush_204_gk.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_landsverk_ush_204_gk.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m3_bradley": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m3_bradley.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m3_bradley",
+      "sourceFileTitle": "us_m3_bradley.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m3_bradley.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_valentine_mk_9": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_valentine_mk_9.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_valentine_mk_9",
+      "sourceFileTitle": "uk_valentine_mk_9.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_valentine_mk_9.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_khalid": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_khalid.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_khalid",
+      "sourceFileTitle": "uk_khalid.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_khalid.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m46_patton": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m46_patton.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m46_patton",
+      "sourceFileTitle": "us_m46_patton.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m46_patton.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_34_comet": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_34_comet.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_34_comet",
+      "sourceFileTitle": "uk_a_34_comet.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_34_comet.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_zsu_57_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_zsu_57_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_zsu_57_2",
+      "sourceFileTitle": "sw_zsu_57_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_zsu_57_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_th_400": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_th_400.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_th_400",
+      "sourceFileTitle": "germ_th_400.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_th_400.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_stug_III_ausf_A": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_stug_iii_ausf_a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_stug_iii_ausf_a",
+      "sourceFileTitle": "germ_stug_iii_ausf_a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_stug_iii_ausf_a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_is_4m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_4m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_is_4m",
+      "sourceFileTitle": "ussr_is_4m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_4m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_chieftain_mk_5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_chieftain_mk_5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_chieftain_mk_5",
+      "sourceFileTitle": "uk_chieftain_mk_5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_chieftain_mk_5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_10_prototype": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_10_prototype.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_10_prototype",
+      "sourceFileTitle": "jp_type_10_prototype.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_10_prototype.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_100_1945": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_100_1945.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_100_1945",
+      "sourceFileTitle": "ussr_su_100_1945.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_100_1945.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_leopard_1a5no": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_leopard_1a5no.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_leopard_1a5no",
+      "sourceFileTitle": "sw_leopard_1a5no.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_leopard_1a5no.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_object_140": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_140.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_object_140",
+      "sourceFileTitle": "ussr_object_140.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_140.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_13_dca_40": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_dca_40.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_13_dca_40",
+      "sourceFileTitle": "fr_amx_13_dca_40.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_dca_40.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m10": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m10.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m10",
+      "sourceFileTitle": "cn_m10.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m10.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_object_279": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_279.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_object_279",
+      "sourceFileTitle": "ussr_object_279.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_279.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_halftrack_m16": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_halftrack_m16.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_halftrack_m16",
+      "sourceFileTitle": "us_halftrack_m16.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_halftrack_m16.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m26_ariete": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m26_ariete.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m26_ariete",
+      "sourceFileTitle": "it_m26_ariete.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m26_ariete.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_vab_santal": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_vab_santal.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_vab_santal",
+      "sourceFileTitle": "fr_vab_santal.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_vab_santal.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_mim_72_chaparral": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_mim_72_chaparral.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_mim_72_chaparral",
+      "sourceFileTitle": "us_mim_72_chaparral.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_mim_72_chaparral.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pbil_m40": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pbil_m40.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pbil_m40",
+      "sourceFileTitle": "sw_pbil_m40.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pbil_m40.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_m42_duster": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m42_duster.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_m42_duster",
+      "sourceFileTitle": "jp_m42_duster.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m42_duster.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_plz_05": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_plz_05.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_plz_05",
+      "sourceFileTitle": "cn_plz_05.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_plz_05.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_xm1_gm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm1_gm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_xm1_gm",
+      "sourceFileTitle": "us_xm1_gm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm1_gm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_Maus": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_maus.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_maus",
+      "sourceFileTitle": "germ_pzkpfw_maus.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_maus.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_pantsyr_s1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_pantsyr_s1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_pantsyr_s1",
+      "sourceFileTitle": "ussr_pantsyr_s1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_pantsyr_s1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_st_b1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_st_b1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_st_b1",
+      "sourceFileTitle": "jp_st_b1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_st_b1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_hq_17": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_hq_17.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_hq_17",
+      "sourceFileTitle": "cn_hq_17.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_hq_17.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_of_40_mk_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_of_40_mk_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_of_40_mk_1",
+      "sourceFileTitle": "it_of_40_mk_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_of_40_mk_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_zsu_23_4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_23_4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_zsu_23_4",
+      "sourceFileTitle": "ussr_zsu_23_4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_23_4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1296_dragoon": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1296_dragoon.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1296_dragoon",
+      "sourceFileTitle": "us_m1296_dragoon.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1296_dragoon.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_object_268": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_268.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_object_268",
+      "sourceFileTitle": "ussr_object_268.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_268.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_zsl_92": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_zsl_92.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_zsl_92",
+      "sourceFileTitle": "cn_zsl_92.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_zsl_92.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_87_rcv_prot": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_87_rcv_prot.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_87_rcv_prot",
+      "sourceFileTitle": "jp_type_87_rcv_prot.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_87_rcv_prot.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_merkava_mk_1b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_1b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_merkava_mk_1b",
+      "sourceFileTitle": "il_merkava_mk_1b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_1b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_challenger_2_megatron": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2_megatron.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_challenger_2_megatron",
+      "sourceFileTitle": "uk_challenger_2_megatron.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2_megatron.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_6b_gal_batash": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6b_gal_batash.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_6b_gal_batash",
+      "sourceFileTitle": "il_magach_6b_gal_batash.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6b_gal_batash.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flarakpz_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flarakpz_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flarakpz_1",
+      "sourceFileTitle": "germ_flarakpz_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flarakpz_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_7c": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_7c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_7c",
+      "sourceFileTitle": "il_magach_7c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_7c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_oto_r3_106sr": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_oto_r3_106sr.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_oto_r3_106sr",
+      "sourceFileTitle": "it_oto_r3_106sr.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_oto_r3_106sr.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_vickers_mk_11": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vickers_mk_11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_vickers_mk_11",
+      "sourceFileTitle": "uk_vickers_mk_11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vickers_mk_11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_zsu_57_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_zsu_57_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_zsu_57_2",
+      "sourceFileTitle": "il_zsu_57_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_zsu_57_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_VI_tiger_P": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_tiger_p.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_vi_tiger_p",
+      "sourceFileTitle": "germ_pzkpfw_vi_tiger_p.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_vi_tiger_p.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m26_pershing": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m26_pershing.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m26_pershing",
+      "sourceFileTitle": "us_m26_pershing.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m26_pershing.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_13_fl_11": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_fl_11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_13_fl_11",
+      "sourceFileTitle": "fr_amx_13_fl_11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_fl_11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_5",
+      "sourceFileTitle": "il_magach_5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_elc_bis": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_elc_bis.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_elc_bis",
+      "sourceFileTitle": "fr_amx_elc_bis.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_elc_bis.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_22b_mk_3_churchill_1942": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_22b_mk_3_churchill_1942.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_22b_mk_3_churchill_1942",
+      "sourceFileTitle": "uk_a_22b_mk_3_churchill_1942.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_22b_mk_3_churchill_1942.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a27m_cromwell_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a27m_cromwell_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a27m_cromwell_1",
+      "sourceFileTitle": "uk_a27m_cromwell_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a27m_cromwell_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_m4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_m4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_m4",
+      "sourceFileTitle": "fr_amx_m4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_m4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_2s19_m2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s19_m2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_2s19_m2",
+      "sourceFileTitle": "ussr_2s19_m2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s19_m2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_2s1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_2s1",
+      "sourceFileTitle": "ussr_2s1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_leopard_2a7_hungary": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_leopard_2a7_hungary.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_leopard_2a7_hungary",
+      "sourceFileTitle": "it_leopard_2a7_hungary.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_leopard_2a7_hungary.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_89b_i_go_otsu": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_89b_i_go_otsu.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_89b_i_go_otsu",
+      "sourceFileTitle": "jp_type_89b_i_go_otsu.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_89b_i_go_otsu.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_122b_plss": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_122b_plss.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_122b_plss",
+      "sourceFileTitle": "sw_strv_122b_plss.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_122b_plss.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_III_ausf_N": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_n.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iii_ausf_n",
+      "sourceFileTitle": "germ_pzkpfw_iii_ausf_n.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_n.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_m109a1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_m109a1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_m109a1",
+      "sourceFileTitle": "il_m109a1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_m109a1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_shir_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_shir_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_shir_2",
+      "sourceFileTitle": "uk_shir_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_shir_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_m44": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m44.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_m44",
+      "sourceFileTitle": "jp_m44.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m44.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m4a4_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m4a4_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m4a4_sherman",
+      "sourceFileTitle": "cn_m4a4_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m4a4_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_63_I": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_63_i.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_63_i",
+      "sourceFileTitle": "cn_type_63_i.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_63_i.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_1941_cast_turret": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_1941_cast_turret.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_1941_cast_turret",
+      "sourceFileTitle": "ussr_t_34_1941_cast_turret.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_1941_cast_turret.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1_ip_abrams": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1_ip_abrams.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1_ip_abrams",
+      "sourceFileTitle": "us_m1_ip_abrams.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1_ip_abrams.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_marder_clovis": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_marder_clovis.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_marder_clovis",
+      "sourceFileTitle": "fr_marder_clovis.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_marder_clovis.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m4a1_sherman_fl_10": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m4a1_sherman_fl_10.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m4a1_sherman_fl_10",
+      "sourceFileTitle": "fr_m4a1_sherman_fl_10.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m4a1_sherman_fl_10.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_navy_120mm_spg": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_navy_120mm_spg.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_navy_120mm_spg",
+      "sourceFileTitle": "jp_navy_120mm_spg.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_navy_120mm_spg.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_fv4005": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv4005.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_fv4005",
+      "sourceFileTitle": "uk_fv4005.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv4005.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m18_super_hellcat": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m18_super_hellcat.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m18_super_hellcat",
+      "sourceFileTitle": "us_m18_super_hellcat.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m18_super_hellcat.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_10": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_10.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_10",
+      "sourceFileTitle": "jp_type_10.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_10.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_IV_ausf_E": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_e.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iv_ausf_e",
+      "sourceFileTitle": "germ_pzkpfw_iv_ausf_e.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iv_ausf_e.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_122_54": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_122_54.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_122_54",
+      "sourceFileTitle": "ussr_su_122_54.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_122_54.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_m113_hvms": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_m113_hvms.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_m113_hvms",
+      "sourceFileTitle": "il_m113_hvms.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_m113_hvms.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_crusader_mk_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_crusader_mk_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_crusader_mk_2",
+      "sourceFileTitle": "uk_crusader_mk_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_crusader_mk_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m10": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m10.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m10",
+      "sourceFileTitle": "us_m10.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m10.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_33_excelsior": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_33_excelsior.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_33_excelsior",
+      "sourceFileTitle": "uk_a_33_excelsior.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_33_excelsior.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_leopard_2a4nl_les": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leopard_2a4nl_les.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_leopard_2a4nl_les",
+      "sourceFileTitle": "fr_leopard_2a4nl_les.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leopard_2a4nl_les.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_m36b2_jgsdf": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m36b2_jgsdf.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_m36b2_jgsdf",
+      "sourceFileTitle": "jp_m36b2_jgsdf.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m36b2_jgsdf.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_su_100_1945": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_su_100_1945.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_su_100_1945",
+      "sourceFileTitle": "cn_su_100_1945.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_su_100_1945.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_26_4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_26_4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_26_4",
+      "sourceFileTitle": "ussr_t_26_4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_26_4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_gaz_mm_72k": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_gaz_mm_72k.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_gaz_mm_72k",
+      "sourceFileTitle": "ussr_gaz_mm_72k.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_gaz_mm_72k.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_is_2_1943": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_is_2_1943.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_is_2_1943",
+      "sourceFileTitle": "cn_is_2_1943.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_is_2_1943.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_centurion_mk_10": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_10.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_centurion_mk_10",
+      "sourceFileTitle": "uk_centurion_mk_10.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_10.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_122": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_122.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_122",
+      "sourceFileTitle": "sw_strv_122.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_122.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1_abrams": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1_abrams.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1_abrams",
+      "sourceFileTitle": "us_m1_abrams.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1_abrams.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_2",
+      "sourceFileTitle": "il_magach_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pvkv_III": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvkv_iii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pvkv_iii",
+      "sourceFileTitle": "sw_pvkv_iii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvkv_iii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_54_1949": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_54_1949.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_54_1949",
+      "sourceFileTitle": "ussr_t_54_1949.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_54_1949.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_xm_975_roland": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm_975_roland.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_xm_975_roland",
+      "sourceFileTitle": "us_xm_975_roland.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm_975_roland.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_fiat_6614_106sr": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_fiat_6614_106sr.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_fiat_6614_106sr",
+      "sourceFileTitle": "it_fiat_6614_106sr.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_fiat_6614_106sr.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_wiesel_1_mk20": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_wiesel_1_mk20.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_wiesel_1_mk20",
+      "sourceFileTitle": "germ_wiesel_1_mk20.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_wiesel_1_mk20.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_lago_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_lago_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_lago_1",
+      "sourceFileTitle": "sw_lago_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_lago_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_adats_bradley": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_adats_bradley.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_adats_bradley",
+      "sourceFileTitle": "us_adats_bradley.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_adats_bradley.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t26e5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t26e5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t26e5",
+      "sourceFileTitle": "us_t26e5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t26e5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_otobreda_sidam_25": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_otobreda_sidam_25.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_otobreda_sidam_25",
+      "sourceFileTitle": "it_otobreda_sidam_25.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_otobreda_sidam_25.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_bat_chat_25t": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_bat_chat_25t.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_bat_chat_25t",
+      "sourceFileTitle": "fr_bat_chat_25t.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_bat_chat_25t.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_l_62_anti_II": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_l_62_anti_ii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_l_62_anti_ii",
+      "sourceFileTitle": "sw_l_62_anti_ii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_l_62_anti_ii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_2s3m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s3m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_2s3m",
+      "sourceFileTitle": "ussr_2s3m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s3m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_challenger_mk_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_mk_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_challenger_mk_3",
+      "sourceFileTitle": "uk_challenger_mk_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_mk_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m36b2_cefeo": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m36b2_cefeo.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m36b2_cefeo",
+      "sourceFileTitle": "fr_m36b2_cefeo.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m36b2_cefeo.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_challenger_1_mk_3_gulf": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_1_mk_3_gulf.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_challenger_1_mk_3_gulf",
+      "sourceFileTitle": "uk_challenger_1_mk_3_gulf.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_1_mk_3_gulf.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t54e2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t54e2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t54e2",
+      "sourceFileTitle": "us_t54e2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t54e2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a3e2_sherman_jumbo": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a3e2_sherman_jumbo.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a3e2_sherman_jumbo",
+      "sourceFileTitle": "us_m4a3e2_sherman_jumbo.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a3e2_sherman_jumbo.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_35t": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_35t.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_35t",
+      "sourceFileTitle": "germ_pzkpfw_35t.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_35t.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_ru251": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_ru251.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_ru251",
+      "sourceFileTitle": "germ_ru251.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_ru251.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m41_a3_walker_bulldog": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m41_a3_walker_bulldog.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m41_a3_walker_bulldog",
+      "sourceFileTitle": "cn_m41_a3_walker_bulldog.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m41_a3_walker_bulldog.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_matilda_hedgehog": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_matilda_hedgehog.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_matilda_hedgehog",
+      "sourceFileTitle": "uk_matilda_hedgehog.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_matilda_hedgehog.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_cm11": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_cm11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_cm11",
+      "sourceFileTitle": "cn_cm11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_cm11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_ajax": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ajax.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_ajax",
+      "sourceFileTitle": "uk_ajax.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ajax.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_isu_152": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_isu_152.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_isu_152",
+      "sourceFileTitle": "ussr_isu_152.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_isu_152.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t18_e2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t18_e2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t18_e2",
+      "sourceFileTitle": "us_t18_e2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t18_e2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_76m_1943": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_76m_1943.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_76m_1943",
+      "sourceFileTitle": "ussr_su_76m_1943.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_76m_1943.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t32": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t32.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t32",
+      "sourceFileTitle": "us_t32.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t32.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_pzkpfw_VI_ausf_e_tiger": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_pzkpfw_vi_ausf_e_tiger.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_pzkpfw_vi_ausf_e_tiger",
+      "sourceFileTitle": "jp_pzkpfw_vi_ausf_e_tiger.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_pzkpfw_vi_ausf_e_tiger.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_54_1951": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_54_1951.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_54_1951",
+      "sourceFileTitle": "ussr_t_54_1951.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_54_1951.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1128_wolfpack": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1128_wolfpack.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1128_wolfpack",
+      "sourceFileTitle": "us_m1128_wolfpack.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1128_wolfpack.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m36b1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m36b1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m36b1",
+      "sourceFileTitle": "it_m36b1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m36b1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a3_105_sherman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a3_105_sherman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a3_105_sherman",
+      "sourceFileTitle": "us_m4a3_105_sherman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a3_105_sherman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_vilkas": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_vilkas.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_vilkas",
+      "sourceFileTitle": "germ_vilkas.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_vilkas.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m551": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m551.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m551",
+      "sourceFileTitle": "us_m551.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m551.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_charioteer_mk_7": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_charioteer_mk_7.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_charioteer_mk_7",
+      "sourceFileTitle": "uk_charioteer_mk_7.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_charioteer_mk_7.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_234_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_234_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_234_1",
+      "sourceFileTitle": "germ_sdkfz_234_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_234_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_sav_m43_1944": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_sav_m43_1944.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_sav_m43_1944",
+      "sourceFileTitle": "sw_sav_m43_1944.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_sav_m43_1944.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_98_ke_ni": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_98_ke_ni.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_98_ke_ni",
+      "sourceFileTitle": "jp_type_98_ke_ni.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_98_ke_ni.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_challenger_2_bn": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2_bn.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_challenger_2_bn",
+      "sourceFileTitle": "uk_challenger_2_bn.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2_bn.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_ariete_amv_pt1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_ariete_amv_pt1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_ariete_amv_pt1",
+      "sourceFileTitle": "it_ariete_amv_pt1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_ariete_amv_pt1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_chieftain_mk_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_chieftain_mk_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_chieftain_mk_3",
+      "sourceFileTitle": "uk_chieftain_mk_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_chieftain_mk_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_59": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_59.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_59",
+      "sourceFileTitle": "cn_type_59.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_59.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_semovente_breda_501": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_breda_501.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_semovente_breda_501",
+      "sourceFileTitle": "it_semovente_breda_501.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_breda_501.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_zsu_23_4m2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_23_4m2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_zsu_23_4m2",
+      "sourceFileTitle": "ussr_zsu_23_4m2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_23_4m2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_to_55": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_to_55.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_to_55",
+      "sourceFileTitle": "ussr_to_55.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_to_55.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_freccia": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_freccia.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_freccia",
+      "sourceFileTitle": "it_freccia.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_freccia.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m47_patton_II": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m47_patton_ii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m47_patton_ii",
+      "sourceFileTitle": "us_m47_patton_ii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m47_patton_ii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m22_locust": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m22_locust.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m22_locust",
+      "sourceFileTitle": "us_m22_locust.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m22_locust.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bmp_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmp_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bmp_3",
+      "sourceFileTitle": "ussr_bmp_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmp_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_38t_na": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_38t_na.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_38t_na",
+      "sourceFileTitle": "germ_pzkpfw_38t_na.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_38t_na.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_6c": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_6c",
+      "sourceFileTitle": "il_magach_6c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_rooikat_za_35": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_rooikat_za_35.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_rooikat_za_35",
+      "sourceFileTitle": "uk_rooikat_za_35.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_rooikat_za_35.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t28": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t28.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t28",
+      "sourceFileTitle": "us_t28.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t28.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_17_pdr_m10_achilles": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_17_pdr_m10_achilles.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_17_pdr_m10_achilles",
+      "sourceFileTitle": "uk_17_pdr_m10_achilles.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_17_pdr_m10_achilles.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m44": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m44.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m44",
+      "sourceFileTitle": "fr_m44.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m44.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_16_mod": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_16_mod.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_16_mod",
+      "sourceFileTitle": "jp_type_16_mod.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_16_mod.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_leopard_bofors": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_leopard_bofors.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_leopard_bofors",
+      "sourceFileTitle": "it_leopard_bofors.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_leopard_bofors.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_234_4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_234_4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_234_4",
+      "sourceFileTitle": "germ_sdkfz_234_4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_234_4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_t_54_1951": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_54_1951.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_t_54_1951",
+      "sourceFileTitle": "sw_t_54_1951.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_54_1951.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m60": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m60",
+      "sourceFileTitle": "us_m60.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m48a1_patton_III": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m48a1_patton_iii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m48a1_patton_iii",
+      "sourceFileTitle": "us_m48a1_patton_iii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m48a1_patton_iii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_otomatic": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_otomatic.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_otomatic",
+      "sourceFileTitle": "it_otomatic.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_otomatic.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_m3_stuart": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_m3_stuart.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_m3_stuart",
+      "sourceFileTitle": "uk_m3_stuart.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_m3_stuart.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_marmon_herrington_mk_6_2pdr": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_marmon_herrington_mk_6_2pdr.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_marmon_herrington_mk_6_2pdr",
+      "sourceFileTitle": "uk_marmon_herrington_mk_6_2pdr.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_marmon_herrington_mk_6_2pdr.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t95": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t95.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t95",
+      "sourceFileTitle": "us_t95.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t95.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_pgz_625_fb10": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_pgz_625_fb10.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_pgz_625_fb10",
+      "sourceFileTitle": "cn_pgz_625_fb10.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_pgz_625_fb10.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flakpanzer_I_ausf_A": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_i_ausf_a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flakpanzer_i_ausf_a",
+      "sourceFileTitle": "germ_flakpanzer_i_ausf_a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_i_ausf_a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_22f_mk_7_churchill_1944": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_22f_mk_7_churchill_1944.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_22f_mk_7_churchill_1944",
+      "sourceFileTitle": "uk_a_22f_mk_7_churchill_1944.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_22f_mk_7_churchill_1944.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m4a4_cn_75_50": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m4a4_cn_75_50.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m4a4_cn_75_50",
+      "sourceFileTitle": "fr_m4a4_cn_75_50.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m4a4_cn_75_50.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_thyssen_henschel_tam_2c": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_thyssen_henschel_tam_2c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_thyssen_henschel_tam_2c",
+      "sourceFileTitle": "germ_thyssen_henschel_tam_2c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_thyssen_henschel_tam_2c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_kungstiger": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_kungstiger.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_kungstiger",
+      "sourceFileTitle": "sw_kungstiger.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_kungstiger.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_50": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_50.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_50",
+      "sourceFileTitle": "ussr_t_50.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_50.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_50_foch": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_50_foch.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_50_foch",
+      "sourceFileTitle": "fr_amx_50_foch.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_50_foch.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_6b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_6b",
+      "sourceFileTitle": "il_magach_6b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m3a1_stuart": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m3a1_stuart.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m3a1_stuart",
+      "sourceFileTitle": "us_m3a1_stuart.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m3a1_stuart.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_pzkpfw_III_ausf_N": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_pzkpfw_iii_ausf_n.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_pzkpfw_iii_ausf_n",
+      "sourceFileTitle": "it_pzkpfw_iii_ausf_n.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_pzkpfw_iii_ausf_n.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_81_tansam": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_81_tansam.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_81_tansam",
+      "sourceFileTitle": "jp_type_81_tansam.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_81_tansam.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1a2_sep_abrams": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a2_sep_abrams.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1a2_sep_abrams",
+      "sourceFileTitle": "us_m1a2_sep_abrams.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a2_sep_abrams.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a27m_cromwell_5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a27m_cromwell_5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a27m_cromwell_5",
+      "sourceFileTitle": "uk_a27m_cromwell_5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a27m_cromwell_5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_object_775": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_775.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_object_775",
+      "sourceFileTitle": "ussr_object_775.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_775.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m2_medium": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m2_medium.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m2_medium",
+      "sourceFileTitle": "us_m2_medium.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m2_medium.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m3a3_stuart": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m3a3_stuart.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m3a3_stuart",
+      "sourceFileTitle": "it_m3a3_stuart.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m3a3_stuart.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_10rc": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_10rc.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_10rc",
+      "sourceFileTitle": "fr_amx_10rc.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_10rc.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_churchill_na75": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_churchill_na75.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_churchill_na75",
+      "sourceFileTitle": "uk_churchill_na75.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_churchill_na75.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m55": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m55.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m55",
+      "sourceFileTitle": "us_m55.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m55.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_isu_122": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_isu_122.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_isu_122",
+      "sourceFileTitle": "ussr_isu_122.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_isu_122.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_armored_car_aec_mk_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_armored_car_aec_mk_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_armored_car_aec_mk_2",
+      "sourceFileTitle": "uk_armored_car_aec_mk_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_armored_car_aec_mk_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2av": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2av.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2av",
+      "sourceFileTitle": "germ_leopard_2av.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2av.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_rooikat_105_td": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_rooikat_105_td.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_rooikat_105_td",
+      "sourceFileTitle": "uk_rooikat_105_td.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_rooikat_105_td.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1a1_hc_abrams": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a1_hc_abrams.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1a1_hc_abrams",
+      "sourceFileTitle": "us_m1a1_hc_abrams.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a1_hc_abrams.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_122P": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_122p.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_122p",
+      "sourceFileTitle": "ussr_su_122p.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_122p.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bmd_4m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmd_4m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bmd_4m",
+      "sourceFileTitle": "ussr_bmd_4m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmd_4m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_9a35_m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_9a35_m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_9a35_m",
+      "sourceFileTitle": "germ_9a35_m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_9a35_m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_kv_122": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_122.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_kv_122",
+      "sourceFileTitle": "ussr_kv_122.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_122.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_hq_11": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_hq_11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_hq_11",
+      "sourceFileTitle": "cn_hq_11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_hq_11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_5_chi_ri": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_5_chi_ri.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_5_chi_ri",
+      "sourceFileTitle": "jp_type_5_chi_ri.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_5_chi_ri.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_nasams_fcs": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_nasams_fcs.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_nasams_fcs",
+      "sourceFileTitle": "us_nasams_fcs.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_nasams_fcs.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t32e1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t32e1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t32e1",
+      "sourceFileTitle": "us_t32e1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t32e1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t86": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t86.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t86",
+      "sourceFileTitle": "us_t86.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t86.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pvkv_iv": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvkv_iv.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pvkv_iv",
+      "sourceFileTitle": "sw_pvkv_iv.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvkv_iv.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_tiran_4_sh": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_tiran_4_sh.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_tiran_4_sh",
+      "sourceFileTitle": "il_tiran_4_sh.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_tiran_4_sh.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_fv221_caernarvon": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv221_caernarvon.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_fv221_caernarvon",
+      "sourceFileTitle": "uk_fv221_caernarvon.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv221_caernarvon.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m10_booker_late": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m10_booker_late.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m10_booker_late",
+      "sourceFileTitle": "us_m10_booker_late.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m10_booker_late.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_zsu_37": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_37.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_zsu_37",
+      "sourceFileTitle": "ussr_zsu_37.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zsu_37.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m55": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m55.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m55",
+      "sourceFileTitle": "cn_m55.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m55.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t114": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t114.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t114",
+      "sourceFileTitle": "us_t114.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t114.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_msc": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_msc.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_msc",
+      "sourceFileTitle": "fr_msc.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_msc.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_kv_2_zis_6": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_2_zis_6.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_kv_2_zis_6",
+      "sourceFileTitle": "ussr_kv_2_zis_6.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_2_zis_6.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_sherman_VII": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_sherman_vii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_sherman_vii",
+      "sourceFileTitle": "it_sherman_vii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_sherman_vii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m56_scorpion": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m56_scorpion.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m56_scorpion",
+      "sourceFileTitle": "us_m56_scorpion.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m56_scorpion.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m44": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m44.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m44",
+      "sourceFileTitle": "us_m44.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m44.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_panzerjager_tiger": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerjager_tiger.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_panzerjager_tiger",
+      "sourceFileTitle": "germ_panzerjager_tiger.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerjager_tiger.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_fv438_swingfire": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv438_swingfire.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_fv438_swingfire",
+      "sourceFileTitle": "uk_fv438_swingfire.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv438_swingfire.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_30_b2_brenus": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_b2_brenus.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_30_b2_brenus",
+      "sourceFileTitle": "fr_amx_30_b2_brenus.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_b2_brenus.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_sholef": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_sholef.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_sholef",
+      "sourceFileTitle": "il_sholef.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_sholef.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_30_super": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_super.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_30_super",
+      "sourceFileTitle": "fr_amx_30_super.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_super.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a27m_cromwell_5_rp3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a27m_cromwell_5_rp3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a27m_cromwell_5_rp3",
+      "sourceFileTitle": "uk_a27m_cromwell_5_rp3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a27m_cromwell_5_rp3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_sky_sabre_fcs": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sky_sabre_fcs.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_sky_sabre_fcs",
+      "sourceFileTitle": "uk_sky_sabre_fcs.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sky_sabre_fcs.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_is_2_1944_321": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_2_1944_321.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_is_2_1944_321",
+      "sourceFileTitle": "ussr_is_2_1944_321.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_2_1944_321.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_wiesel_2_adwc": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_wiesel_2_adwc.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_wiesel_2_adwc",
+      "sourceFileTitle": "germ_wiesel_2_adwc.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_wiesel_2_adwc.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_semovente_m43_75_46": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m43_75_46.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_semovente_m43_75_46",
+      "sourceFileTitle": "it_semovente_m43_75_46.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m43_75_46.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amd_35": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amd_35.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amd_35",
+      "sourceFileTitle": "fr_amd_35.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amd_35.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_251_21": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_251_21.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_251_21",
+      "sourceFileTitle": "germ_sdkfz_251_21.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_251_21.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sturmpanzer_II": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sturmpanzer_ii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sturmpanzer_ii",
+      "sourceFileTitle": "germ_sturmpanzer_ii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sturmpanzer_ii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_9p157": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_9p157.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_9p157",
+      "sourceFileTitle": "ussr_9p157.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_9p157.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_m55": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_m55.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_m55",
+      "sourceFileTitle": "germ_m55.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_m55.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_pgz_09": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_pgz_09.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_pgz_09",
+      "sourceFileTitle": "cn_pgz_09.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_pgz_09.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_wiesel_1_tow": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_wiesel_1_tow.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_wiesel_1_tow",
+      "sourceFileTitle": "germ_wiesel_1_tow.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_wiesel_1_tow.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t95e1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t95e1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t95e1",
+      "sourceFileTitle": "us_t95e1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t95e1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_6a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_6a",
+      "sourceFileTitle": "il_magach_6a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_kv_2_1940": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_2_1940.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_kv_2_1940",
+      "sourceFileTitle": "ussr_kv_2_1940.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_kv_2_1940.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_merkava_mk_3_raam_segol": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_3_raam_segol.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_merkava_mk_3_raam_segol",
+      "sourceFileTitle": "il_merkava_mk_3_raam_segol.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_3_raam_segol.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m109g": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m109g.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m109g",
+      "sourceFileTitle": "it_m109g.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m109g.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ptz_89": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ptz_89.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ptz_89",
+      "sourceFileTitle": "cn_ptz_89.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ptz_89.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_btr_zd": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_btr_zd.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_btr_zd",
+      "sourceFileTitle": "ussr_btr_zd.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_btr_zd.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a3e8_76w_sherman_kit_3rank": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a3e8_76w_sherman_kit_3rank.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a3e8_76w_sherman_kit_3rank",
+      "sourceFileTitle": "us_m4a3e8_76w_sherman_kit_3rank.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a3e8_76w_sherman_kit_3rank.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_su_76m_1943": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_su_76m_1943.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_su_76m_1943",
+      "sourceFileTitle": "cn_su_76m_1943.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_su_76m_1943.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_boxer_crv_block2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_boxer_crv_block2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_boxer_crv_block2",
+      "sourceFileTitle": "uk_boxer_crv_block2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_boxer_crv_block2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m18_hellcat_kit_3rank": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m18_hellcat_kit_3rank.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m18_hellcat_kit_3rank",
+      "sourceFileTitle": "us_m18_hellcat_kit_3rank.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m18_hellcat_kit_3rank.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_m109g": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_m109g.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_m109g",
+      "sourceFileTitle": "germ_m109g.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_m109g.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_object_120": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_120.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_object_120",
+      "sourceFileTitle": "ussr_object_120.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_120.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m60a2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60a2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m60a2",
+      "sourceFileTitle": "us_m60a2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60a2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_merkava_mk_4m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_4m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_merkava_mk_4m",
+      "sourceFileTitle": "il_merkava_mk_4m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_4m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_t_55m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_55m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_t_55m",
+      "sourceFileTitle": "sw_t_55m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_55m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_m48a1_patton_III": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_m48a1_patton_iii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_m48a1_patton_iii",
+      "sourceFileTitle": "il_m48a1_patton_iii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_m48a1_patton_iii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_jaguar_ebrc": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_jaguar_ebrc.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_jaguar_ebrc",
+      "sourceFileTitle": "fr_jaguar_ebrc.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_jaguar_ebrc.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1a1_abrams": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a1_abrams.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1a1_abrams",
+      "sourceFileTitle": "us_m1a1_abrams.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a1_abrams.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_leclerc_azur": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leclerc_azur.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_leclerc_azur",
+      "sourceFileTitle": "fr_leclerc_azur.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leclerc_azur.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_leopard_2a6nl": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leopard_2a6nl.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_leopard_2a6nl",
+      "sourceFileTitle": "fr_leopard_2a6nl.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leopard_2a6nl.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_pzh_2000_hu": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_pzh_2000_hu.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_pzh_2000_hu",
+      "sourceFileTitle": "it_pzh_2000_hu.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_pzh_2000_hu.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strf_90c": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strf_90c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strf_90c",
+      "sourceFileTitle": "sw_strf_90c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strf_90c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_semovente_m42_75_34": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m42_75_34.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_semovente_m42_75_34",
+      "sourceFileTitle": "it_semovente_m42_75_34.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m42_75_34.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_ab_43": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_ab_43.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_ab_43",
+      "sourceFileTitle": "it_ab_43.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_ab_43.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_xm_8": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm_8.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_xm_8",
+      "sourceFileTitle": "us_xm_8.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm_8.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_72m2_moderna": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72m2_moderna.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_72m2_moderna",
+      "sourceFileTitle": "ussr_t_72m2_moderna.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_72m2_moderna.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_II_ausf_H": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_ii_ausf_h.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_ii_ausf_h",
+      "sourceFileTitle": "germ_pzkpfw_ii_ausf_h.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_ii_ausf_h.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_leclerc_sxxi": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leclerc_sxxi.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_leclerc_sxxi",
+      "sourceFileTitle": "fr_leclerc_sxxi.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leclerc_sxxi.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_III_ausf_L": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_l.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iii_ausf_l",
+      "sourceFileTitle": "germ_pzkpfw_iii_ausf_l.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_l.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_leclerc_s2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leclerc_s2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_leclerc_s2",
+      "sourceFileTitle": "fr_leclerc_s2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leclerc_s2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_234_2_mod": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_234_2_mod.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_234_2_mod",
+      "sourceFileTitle": "germ_sdkfz_234_2_mod.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_234_2_mod.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_tiran_4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_tiran_4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_tiran_4",
+      "sourceFileTitle": "il_tiran_4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_tiran_4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_is_2_1944": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_is_2_1944.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_is_2_1944",
+      "sourceFileTitle": "cn_is_2_1944.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_is_2_1944.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_vcac_mephisto": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_vcac_mephisto.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_vcac_mephisto",
+      "sourceFileTitle": "fr_vcac_mephisto.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_vcac_mephisto.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_chieftain_marksman": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_chieftain_marksman.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_chieftain_marksman",
+      "sourceFileTitle": "uk_chieftain_marksman.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_chieftain_marksman.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m48a1_patton_III": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m48a1_patton_iii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m48a1_patton_iii",
+      "sourceFileTitle": "cn_m48a1_patton_iii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m48a1_patton_iii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_30_ACRA": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_acra.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_30_acra",
+      "sourceFileTitle": "fr_amx_30_acra.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_acra.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_xm_800t": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm_800t.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_xm_800t",
+      "sourceFileTitle": "us_xm_800t.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm_800t.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m55": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m55.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m55",
+      "sourceFileTitle": "fr_m55.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m55.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_16": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_16.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_16",
+      "sourceFileTitle": "jp_type_16.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_16.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_126sp": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_126sp.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_126sp",
+      "sourceFileTitle": "ussr_t_126sp.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_126sp.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_251_10": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_251_10.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_251_10",
+      "sourceFileTitle": "germ_sdkfz_251_10.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_251_10.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_object_248": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_248.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_object_248",
+      "sourceFileTitle": "ussr_object_248.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_248.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flakpanzer_zerstorer_45": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_zerstorer_45.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flakpanzer_zerstorer_45",
+      "sourceFileTitle": "germ_flakpanzer_zerstorer_45.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_zerstorer_45.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_char_2c": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_char_2c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_char_2c",
+      "sourceFileTitle": "fr_char_2c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_char_2c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m42_duster": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m42_duster.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m42_duster",
+      "sourceFileTitle": "cn_m42_duster.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m42_duster.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_40": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_40.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_40",
+      "sourceFileTitle": "fr_amx_40.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_40.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_merkava_mk_3b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_3b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_merkava_mk_3b",
+      "sourceFileTitle": "il_merkava_mk_3b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_3b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_valentine_mk_11": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_valentine_mk_11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_valentine_mk_11",
+      "sourceFileTitle": "uk_valentine_mk_11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_valentine_mk_11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_vrcc_centauro": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_vrcc_centauro.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_vrcc_centauro",
+      "sourceFileTitle": "it_vrcc_centauro.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_vrcc_centauro.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_is_6": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_6.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_is_6",
+      "sourceFileTitle": "ussr_is_6.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_6.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m18_hellcat": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m18_hellcat.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m18_hellcat",
+      "sourceFileTitle": "it_m18_hellcat.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m18_hellcat.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_89": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_89.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_89",
+      "sourceFileTitle": "jp_type_89.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_89.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_ccvl": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_ccvl.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_ccvl",
+      "sourceFileTitle": "us_ccvl.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_ccvl.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_m109a1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_m109a1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_m109a1",
+      "sourceFileTitle": "uk_m109a1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_m109a1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_vt_4b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_vt_4b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_vt_4b",
+      "sourceFileTitle": "cn_vt_4b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_vt_4b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_74_f": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_74_f.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_74_f",
+      "sourceFileTitle": "jp_type_74_f.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_74_f.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_57": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_57.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_57",
+      "sourceFileTitle": "ussr_su_57.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_57.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_btr_80a_hungary": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_btr_80a_hungary.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_btr_80a_hungary",
+      "sourceFileTitle": "it_btr_80a_hungary.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_btr_80a_hungary.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_122": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_122.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_122",
+      "sourceFileTitle": "ussr_su_122.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_122.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_merkava_mk_3c": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_3c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_merkava_mk_3c",
+      "sourceFileTitle": "il_merkava_mk_3c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_3c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_semovente_m43_105_leoncello": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m43_105_leoncello.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_semovente_m43_105_leoncello",
+      "sourceFileTitle": "it_semovente_m43_105_leoncello.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m43_105_leoncello.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_ikv_72": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_ikv_72.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_ikv_72",
+      "sourceFileTitle": "sw_ikv_72.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_ikv_72.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_pzkpfw_V_panther_dauphine": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_pzkpfw_v_panther_dauphine.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_pzkpfw_v_panther_dauphine",
+      "sourceFileTitle": "fr_pzkpfw_v_panther_dauphine.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_pzkpfw_v_panther_dauphine.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_m3a1_stuart": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_m3a1_stuart.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_m3a1_stuart",
+      "sourceFileTitle": "uk_m3a1_stuart.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_m3a1_stuart.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_9a33bm3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_9a33bm3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_9a33bm3",
+      "sourceFileTitle": "ussr_9a33bm3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_9a33bm3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_challenger_2_lep": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2_lep.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_challenger_2_lep",
+      "sourceFileTitle": "uk_challenger_2_lep.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2_lep.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_m40l": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m40l.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_m40l",
+      "sourceFileTitle": "sw_strv_m40l.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m40l.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m109a1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m109a1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m109a1",
+      "sourceFileTitle": "us_m109a1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m109a1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_fiat_cm52": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_fiat_cm52.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_fiat_cm52",
+      "sourceFileTitle": "it_fiat_cm52.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_fiat_cm52.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_m60a3_tts": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m60a3_tts.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_m60a3_tts",
+      "sourceFileTitle": "jp_m60a3_tts.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m60a3_tts.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t55e1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t55e1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t55e1",
+      "sourceFileTitle": "us_t55e1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t55e1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_centurion_mk_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_centurion_mk_1",
+      "sourceFileTitle": "uk_centurion_mk_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_zsu_23_4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_zsu_23_4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_zsu_23_4",
+      "sourceFileTitle": "it_zsu_23_4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_zsu_23_4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_object_685": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_685.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_object_685",
+      "sourceFileTitle": "ussr_object_685.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_object_685.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_infanterie_kampfpanzer_churchill": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_infanterie_kampfpanzer_churchill.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_infanterie_kampfpanzer_churchill",
+      "sourceFileTitle": "germ_infanterie_kampfpanzer_churchill.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_infanterie_kampfpanzer_churchill.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_75": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_75.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_75",
+      "sourceFileTitle": "jp_type_75.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_75.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_22f_mk_7_churchill_crocodile": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_22f_mk_7_churchill_crocodile.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_22f_mk_7_churchill_crocodile",
+      "sourceFileTitle": "uk_a_22f_mk_7_churchill_crocodile.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_22f_mk_7_churchill_crocodile.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_34_comet_iron_duke": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_34_comet_iron_duke.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_34_comet_iron_duke",
+      "sourceFileTitle": "uk_a_34_comet_iron_duke.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_34_comet_iron_duke.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_III_ausf_J": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_j.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iii_ausf_j",
+      "sourceFileTitle": "germ_pzkpfw_iii_ausf_j.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_j.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_olifant_mk_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_olifant_mk_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_olifant_mk_2",
+      "sourceFileTitle": "uk_olifant_mk_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_olifant_mk_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_10p": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_10p.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_10p",
+      "sourceFileTitle": "fr_amx_10p.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_10p.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m13_40_serie_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m13_40_serie_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m13_40_serie_1",
+      "sourceFileTitle": "it_m13_40_serie_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m13_40_serie_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_t77e1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_t77e1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_t77e1",
+      "sourceFileTitle": "us_t77e1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_t77e1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_merkava_mk_4b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_4b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_merkava_mk_4b",
+      "sourceFileTitle": "il_merkava_mk_4b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_4b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2a4m_can_sm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a4m_can_sm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2a4m_can_sm",
+      "sourceFileTitle": "germ_leopard_2a4m_can_sm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a4m_can_sm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m47_105": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m47_105.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m47_105",
+      "sourceFileTitle": "it_m47_105.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m47_105.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_gmc_cckw_353_m45_quad": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_gmc_cckw_353_m45_quad.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_gmc_cckw_353_m45_quad",
+      "sourceFileTitle": "cn_gmc_cckw_353_m45_quad.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_gmc_cckw_353_m45_quad.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_ratel_90": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ratel_90.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_ratel_90",
+      "sourceFileTitle": "uk_ratel_90.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ratel_90.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_challenger_2e": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2e.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_challenger_2e",
+      "sourceFileTitle": "uk_challenger_2e.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2e.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_fv721_fox": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv721_fox.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_fv721_fox",
+      "sourceFileTitle": "uk_fv721_fox.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv721_fox.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_crusader_aa_mk_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_crusader_aa_mk_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_crusader_aa_mk_2",
+      "sourceFileTitle": "uk_crusader_aa_mk_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_crusader_aa_mk_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sppz2_luchs_a2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sppz2_luchs_a2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sppz2_luchs_a2",
+      "sourceFileTitle": "germ_sppz2_luchs_a2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sppz2_luchs_a2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_btr_152a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_btr_152a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_btr_152a",
+      "sourceFileTitle": "ussr_btr_152a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_btr_152a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_zsd63_pg87": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_zsd63_pg87.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_zsd63_pg87",
+      "sourceFileTitle": "cn_zsd63_pg87.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_zsd63_pg87.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_skink_aa": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_skink_aa.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_skink_aa",
+      "sourceFileTitle": "us_skink_aa.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_skink_aa.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_bmp_1_ddr": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_bmp_1_ddr.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_bmp_1_ddr",
+      "sourceFileTitle": "germ_bmp_1_ddr.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_bmp_1_ddr.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_99": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_99.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_99",
+      "sourceFileTitle": "jp_type_99.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_99.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_stuh_III_ausf_G": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_stuh_iii_ausf_g.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_stuh_iii_ausf_g",
+      "sourceFileTitle": "germ_stuh_iii_ausf_g.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_stuh_iii_ausf_g.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_32_105": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_32_105.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_32_105",
+      "sourceFileTitle": "fr_amx_32_105.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_32_105.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_panhard_ebr_1951": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_panhard_ebr_1951.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_panhard_ebr_1951",
+      "sourceFileTitle": "fr_panhard_ebr_1951.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_panhard_ebr_1951.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_crusader_mk_2_the_saint": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_crusader_mk_2_the_saint.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_crusader_mk_2_the_saint",
+      "sourceFileTitle": "uk_crusader_mk_2_the_saint.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_crusader_mk_2_the_saint.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_87_rcv": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_87_rcv.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_87_rcv",
+      "sourceFileTitle": "jp_type_87_rcv.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_87_rcv.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_ystervark_spaa": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ystervark_spaa.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_ystervark_spaa",
+      "sourceFileTitle": "uk_ystervark_spaa.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ystervark_spaa.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_m39_td": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m39_td.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_m39_td",
+      "sourceFileTitle": "sw_strv_m39_td.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m39_td.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_semovente_m43_105": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m43_105.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_semovente_m43_105",
+      "sourceFileTitle": "it_semovente_m43_105.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m43_105.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_panzerwerfer_42": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerwerfer_42.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_panzerwerfer_42",
+      "sourceFileTitle": "germ_panzerwerfer_42.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerwerfer_42.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_2s25": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s25.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_2s25",
+      "sourceFileTitle": "ussr_2s25.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_2s25.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_zprk_2s6": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zprk_2s6.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_zprk_2s6",
+      "sourceFileTitle": "ussr_zprk_2s6.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zprk_2s6.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sturmmorser_sturmtiger": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sturmmorser_sturmtiger.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sturmmorser_sturmtiger",
+      "sourceFileTitle": "germ_sturmmorser_sturmtiger.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sturmmorser_sturmtiger.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_semovente_l40": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_l40.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_semovente_l40",
+      "sourceFileTitle": "it_semovente_l40.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_l40.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_semovente_m41_75_18": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m41_75_18.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_semovente_m41_75_18",
+      "sourceFileTitle": "it_semovente_m41_75_18.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m41_75_18.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_semovente_m41_75_32": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m41_75_32.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_semovente_m41_75_32",
+      "sourceFileTitle": "it_semovente_m41_75_32.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m41_75_32.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_semovente_m43_75_34": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m43_75_34.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_semovente_m43_75_34",
+      "sourceFileTitle": "it_semovente_m43_75_34.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m43_75_34.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_buk_m3_launcher": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_buk_m3_launcher.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_buk_m3_launcher",
+      "sourceFileTitle": "ussr_buk_m3_launcher.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_buk_m3_launcher.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_buk_m3_fcs": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_buk_m3_fcs.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_buk_m3_fcs",
+      "sourceFileTitle": "ussr_buk_m3_fcs.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_buk_m3_fcs.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_ac1_sentinel": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ac1_sentinel.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_ac1_sentinel",
+      "sourceFileTitle": "uk_ac1_sentinel.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ac1_sentinel.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_13_mk1_3rd_rtr": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_13_mk1_3rd_rtr.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_13_mk1_3rd_rtr",
+      "sourceFileTitle": "uk_a_13_mk1_3rd_rtr.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_13_mk1_3rd_rtr.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_13_mk2_1939": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_13_mk2_1939.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_13_mk2_1939",
+      "sourceFileTitle": "uk_a_13_mk2_1939.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_13_mk2_1939.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_a7v": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_a7v.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_a7v",
+      "sourceFileTitle": "germ_a7v.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_a7v.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_ab_41": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_ab_41.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_ab_41",
+      "sourceFileTitle": "it_ab_41.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_ab_41.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_adats_m113a3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_adats_m113a3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_adats_m113a3",
+      "sourceFileTitle": "uk_adats_m113a3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_adats_m113a3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_armored_car_mk_2_aa": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_armored_car_mk_2_aa.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_armored_car_mk_2_aa",
+      "sourceFileTitle": "uk_armored_car_mk_2_aa.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_armored_car_mk_2_aa.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_hj_9": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_hj_9.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_hj_9",
+      "sourceFileTitle": "cn_hj_9.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_hj_9.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_ags_teledyne": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_ags_teledyne.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_ags_teledyne",
+      "sourceFileTitle": "us_ags_teledyne.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_ags_teledyne.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_alecto_mk_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_alecto_mk_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_alecto_mk_1",
+      "sourceFileTitle": "uk_alecto_mk_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_alecto_mk_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amc_34": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amc_34.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amc_34",
+      "sourceFileTitle": "fr_amc_34.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amc_34.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amc_35": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amc_35.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amc_35",
+      "sourceFileTitle": "fr_amc_35.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amc_35.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amd_35_kwk39": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amd_35_kwk39.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amd_35_kwk39",
+      "sourceFileTitle": "fr_amd_35_kwk39.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amd_35_kwk39.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_aml_90": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_aml_90.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_aml_90",
+      "sourceFileTitle": "fr_aml_90.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_aml_90.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amr_35_zt3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amr_35_zt3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amr_35_zt3",
+      "sourceFileTitle": "fr_amr_35_zt3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amr_35_zt3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_10m_acra": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_10m_acra.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_10m_acra",
+      "sourceFileTitle": "fr_amx_10m_acra.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_10m_acra.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_13_75": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_75.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_13_75",
+      "sourceFileTitle": "fr_amx_13_75.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_75.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_13_hot": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_hot.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_13_hot",
+      "sourceFileTitle": "fr_amx_13_hot.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_hot.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_13_75_ss11": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_75_ss11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_13_75_ss11",
+      "sourceFileTitle": "fr_amx_13_75_ss11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_75_ss11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_13_chaffee": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_chaffee.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_13_chaffee",
+      "sourceFileTitle": "fr_amx_13_chaffee.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_13_chaffee.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_32": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_32.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_32",
+      "sourceFileTitle": "fr_amx_32.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_32.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_50_1950": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_50_1950.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_50_1950",
+      "sourceFileTitle": "fr_amx_50_1950.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_50_1950.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_50_surblinde": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_50_surblinde.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_50_surblinde",
+      "sourceFileTitle": "fr_amx_50_surblinde.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_50_surblinde.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_antelope_tc_1l_ads": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_antelope_tc_1l_ads.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_antelope_tc_1l_ads",
+      "sourceFileTitle": "cn_antelope_tc_1l_ads.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_antelope_tc_1l_ads.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_sp_17_pdr_valentine": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sp_17_pdr_valentine.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_sp_17_pdr_valentine",
+      "sourceFileTitle": "uk_sp_17_pdr_valentine.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sp_17_pdr_valentine.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_c1_ariete": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_c1_ariete.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_c1_ariete",
+      "sourceFileTitle": "it_c1_ariete.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_c1_ariete.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_c1_ariete_pso": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_c1_ariete_pso.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_c1_ariete_pso",
+      "sourceFileTitle": "it_c1_ariete_pso.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_c1_ariete_pso.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_c1_ariete_certezza": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_c1_ariete_certezza.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_c1_ariete_certezza",
+      "sourceFileTitle": "it_c1_ariete_certezza.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_c1_ariete_certezza.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_as_42_metropolitana": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_as_42_metropolitana.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_as_42_metropolitana",
+      "sourceFileTitle": "it_as_42_metropolitana.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_as_42_metropolitana.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_asrad_r": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_asrad_r.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_asrad_r",
+      "sourceFileTitle": "sw_asrad_r.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_asrad_r.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_fiat_6616_cockerill": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_fiat_6616_cockerill.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_fiat_6616_cockerill",
+      "sourceFileTitle": "it_fiat_6616_cockerill.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_fiat_6616_cockerill.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_aubl_74_60_70m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_aubl_74_60_70m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_aubl_74_60_70m",
+      "sourceFileTitle": "it_aubl_74_60_70m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_aubl_74_60_70m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_30_auf_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_auf_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_30_auf_1",
+      "sourceFileTitle": "fr_amx_30_auf_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_auf_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a30_sp_avenger_kit_3rank": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a30_sp_avenger_kit_3rank.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a30_sp_avenger_kit_3rank",
+      "sourceFileTitle": "uk_a30_sp_avenger_kit_3rank.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a30_sp_avenger_kit_3rank.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_b1_bis": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_b1_bis.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_b1_bis",
+      "sourceFileTitle": "fr_b1_bis.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_b1_bis.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_b1_ter": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_b1_ter.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_b1_ter",
+      "sourceFileTitle": "fr_b1_ter.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_b1_ter.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_ba_11": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_ba_11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_ba_11",
+      "sourceFileTitle": "ussr_ba_11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_ba_11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_badger": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_badger.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_badger",
+      "sourceFileTitle": "uk_badger.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_badger.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_beutepanzer_mk_iv": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_beutepanzer_mk_iv.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_beutepanzer_mk_iv",
+      "sourceFileTitle": "germ_beutepanzer_mk_iv.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_beutepanzer_mk_iv.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bm_13n": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bm_13n.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bm_13n",
+      "sourceFileTitle": "ussr_bm_13n.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bm_13n.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bm_31_12": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bm_31_12.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bm_31_12",
+      "sourceFileTitle": "ussr_bm_31_12.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bm_31_12.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bm_8_24": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bm_8_24.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bm_8_24",
+      "sourceFileTitle": "ussr_bm_8_24.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bm_8_24.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bmd_4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmd_4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bmd_4",
+      "sourceFileTitle": "ussr_bmd_4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmd_4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bmp_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmp_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bmp_1",
+      "sourceFileTitle": "ussr_bmp_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmp_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bmp_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmp_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bmp_2",
+      "sourceFileTitle": "ussr_bmp_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bmp_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_bmp_2md": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_bmp_2md.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_bmp_2md",
+      "sourceFileTitle": "sw_bmp_2md.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_bmp_2md.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_bosvark": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_bosvark.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_bosvark",
+      "sourceFileTitle": "uk_bosvark.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_bosvark.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_boxer_3105": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_boxer_3105.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_boxer_3105",
+      "sourceFileTitle": "germ_boxer_3105.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_boxer_3105.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_breda_52_autocannone": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_breda_52_autocannone.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_breda_52_autocannone",
+      "sourceFileTitle": "it_breda_52_autocannone.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_breda_52_autocannone.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bt_7_1937_td": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bt_7_1937_td.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bt_7_1937_td",
+      "sourceFileTitle": "ussr_bt_7_1937_td.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bt_7_1937_td.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_bt_7a_f32": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bt_7a_f32.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_bt_7a_f32",
+      "sourceFileTitle": "ussr_bt_7a_f32.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_bt_7a_f32.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_c13_t90": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_c13_t90.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_c13_t90",
+      "sourceFileTitle": "it_c13_t90.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_c13_t90.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_c13_tua": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_c13_tua.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_c13_tua",
+      "sourceFileTitle": "it_c13_tua.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_c13_tua.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_c2_mexas": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_c2_mexas.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_c2_mexas",
+      "sourceFileTitle": "germ_leopard_c2_mexas.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_c2_mexas.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_lorraine_100": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_lorraine_100.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_lorraine_100",
+      "sourceFileTitle": "fr_lorraine_100.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_lorraine_100.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_cckw_353_bofors": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_cckw_353_bofors.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_cckw_353_bofors",
+      "sourceFileTitle": "fr_cckw_353_bofors.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_cckw_353_bofors.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_sahariano": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_sahariano.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_sahariano",
+      "sourceFileTitle": "it_sahariano.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_sahariano.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_b1_centauro": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_b1_centauro.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_b1_centauro",
+      "sourceFileTitle": "it_b1_centauro.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_b1_centauro.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_b1_centauro_romor": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_b1_centauro_romor.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_b1_centauro_romor",
+      "sourceFileTitle": "it_b1_centauro_romor.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_b1_centauro_romor.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_centauro_mgs_120": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_centauro_mgs_120.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_centauro_mgs_120",
+      "sourceFileTitle": "it_centauro_mgs_120.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_centauro_mgs_120.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_centauro_rgo_120": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_centauro_rgo_120.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_centauro_rgo_120",
+      "sourceFileTitle": "it_centauro_rgo_120.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_centauro_rgo_120.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_centurion_action_x": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_action_x.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_centurion_action_x",
+      "sourceFileTitle": "uk_centurion_action_x.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_action_x.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_centurion_mk_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_centurion_mk_3",
+      "sourceFileTitle": "uk_centurion_mk_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_centurion_mk_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_centurion_mk_2",
+      "sourceFileTitle": "uk_centurion_mk_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_centurion_mk_5_avre_era": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_5_avre_era.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_centurion_mk_5_avre_era",
+      "sourceFileTitle": "uk_centurion_mk_5_avre_era.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_5_avre_era.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_centurion_mk_5_raac": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_5_raac.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_centurion_mk_5_raac",
+      "sourceFileTitle": "uk_centurion_mk_5_raac.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_5_raac.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_challenger_2_dorchester": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2_dorchester.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_challenger_2_dorchester",
+      "sourceFileTitle": "uk_challenger_2_dorchester.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2_dorchester.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_challenger_2_tes": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2_tes.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_challenger_2_tes",
+      "sourceFileTitle": "uk_challenger_2_tes.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2_tes.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_97_kai": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_97_kai.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_97_kai",
+      "sourceFileTitle": "jp_type_97_kai.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_97_kai.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_97_kai_td": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_97_kai_td.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_97_kai_td",
+      "sourceFileTitle": "jp_type_97_kai_td.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_97_kai_td.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_97_chi_ha_12cm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_97_chi_ha_12cm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_97_chi_ha_12cm",
+      "sourceFileTitle": "jp_type_97_chi_ha_12cm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_97_chi_ha_12cm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_1_chi_he": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_1_chi_he.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_1_chi_he",
+      "sourceFileTitle": "jp_type_1_chi_he.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_1_chi_he.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_1_chi_he_5th_regiment": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_1_chi_he_5th_regiment.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_1_chi_he_5th_regiment",
+      "sourceFileTitle": "jp_type_1_chi_he_5th_regiment.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_1_chi_he_5th_regiment.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_churchill_avre": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_churchill_avre.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_churchill_avre",
+      "sourceFileTitle": "uk_churchill_avre.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_churchill_avre.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a_22_mk_1_churchill_1941": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_22_mk_1_churchill_1941.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a_22_mk_1_churchill_1941",
+      "sourceFileTitle": "uk_a_22_mk_1_churchill_1941.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a_22_mk_1_churchill_1941.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_th_800_bismark": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_th_800_bismark.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_th_800_bismark",
+      "sourceFileTitle": "germ_th_800_bismark.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_th_800_bismark.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_sl_amraam_launcher": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_sl_amraam_launcher.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_sl_amraam_launcher",
+      "sourceFileTitle": "us_sl_amraam_launcher.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_sl_amraam_launcher.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_sl_amraam_fcs": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_sl_amraam_fcs.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_sl_amraam_fcs",
+      "sourceFileTitle": "us_sl_amraam_fcs.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_sl_amraam_fcs.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_cm_25": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_cm_25.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_cm_25",
+      "sourceFileTitle": "cn_cm_25.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_cm_25.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_cm_34": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_cm_34.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_cm_34",
+      "sourceFileTitle": "cn_cm_34.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_cm_34.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_fv4004_conway": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv4004_conway.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_fv4004_conway",
+      "sourceFileTitle": "uk_fv4004_conway.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv4004_conway.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_crusader_aa_mk_2_kit_3rank": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_crusader_aa_mk_2_kit_3rank.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_crusader_aa_mk_2_kit_3rank",
+      "sourceFileTitle": "uk_crusader_aa_mk_2_kit_3rank.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_crusader_aa_mk_2_kit_3rank.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_crusader_aa_mk_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_crusader_aa_mk_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_crusader_aa_mk_1",
+      "sourceFileTitle": "uk_crusader_aa_mk_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_crusader_aa_mk_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_crusader_mk_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_crusader_mk_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_crusader_mk_3",
+      "sourceFileTitle": "uk_crusader_mk_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_crusader_mk_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_crusader_mk_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_crusader_mk_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_crusader_mk_2",
+      "sourceFileTitle": "fr_crusader_mk_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_crusader_mk_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_39m_csaba": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_39m_csaba.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_39m_csaba",
+      "sourceFileTitle": "it_39m_csaba.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_39m_csaba.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_patria_amv_ctcv_105": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_patria_amv_ctcv_105.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_patria_amv_ctcv_105",
+      "sourceFileTitle": "sw_patria_amv_ctcv_105.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_patria_amv_ctcv_105.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_icv_prototype": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_icv_prototype.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_icv_prototype",
+      "sourceFileTitle": "jp_icv_prototype.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_icv_prototype.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_cv_90_mk4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_cv_90_mk4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_cv_90_mk4",
+      "sourceFileTitle": "sw_cv_90_mk4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_cv_90_mk4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_cv_90105": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_cv_90105.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_cv_90105",
+      "sourceFileTitle": "sw_cv_90105.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_cv_90105.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_cv_9035_nl": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_cv_9035_nl.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_cv_9035_nl",
+      "sourceFileTitle": "fr_cv_9035_nl.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_cv_9035_nl.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_cv_9030_fin": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_cv_9030_fin.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_cv_9030_fin",
+      "sourceFileTitle": "sw_cv_9030_fin.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_cv_9030_fin.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_cv_9035_dk": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_cv_9035_dk.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_cv_9035_dk",
+      "sourceFileTitle": "sw_cv_9035_dk.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_cv_9035_dk.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_renault_d2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_renault_d2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_renault_d2",
+      "sourceFileTitle": "fr_renault_d2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_renault_d2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_daimler_mk_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_daimler_mk_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_daimler_mk_2",
+      "sourceFileTitle": "uk_daimler_mk_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_daimler_mk_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_dardo_vcc": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_dardo_vcc.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_dardo_vcc",
+      "sourceFileTitle": "it_dardo_vcc.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_dardo_vcc.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_desert_warrior": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_desert_warrior.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_desert_warrior",
+      "sourceFileTitle": "uk_desert_warrior.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_desert_warrior.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_e_100": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_e_100.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_e_100",
+      "sourceFileTitle": "germ_pzkpfw_e_100.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_e_100.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_panhard_ebr_1963": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_panhard_ebr_1963.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_panhard_ebr_1963",
+      "sourceFileTitle": "fr_panhard_ebr_1963.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_panhard_ebr_1963.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_efv_p1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_efv_p1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_efv_p1",
+      "sourceFileTitle": "us_efv_p1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_efv_p1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_eitan": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_eitan.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_eitan",
+      "sourceFileTitle": "il_eitan.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_eitan.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_eland_90_mk_7": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_eland_90_mk_7.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_eland_90_mk_7",
+      "sourceFileTitle": "uk_eland_90_mk_7.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_eland_90_mk_7.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_eldenhet_98": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_eldenhet_98.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_eldenhet_98",
+      "sourceFileTitle": "sw_eldenhet_98.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_eldenhet_98.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_falcon": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_falcon.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_falcon",
+      "sourceFileTitle": "uk_falcon.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_falcon.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_fcm_36": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_fcm_36.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_fcm_36",
+      "sourceFileTitle": "fr_fcm_36.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_fcm_36.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_sherman_vc_firefly_kit_3rank": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sherman_vc_firefly_kit_3rank.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_sherman_vc_firefly_kit_3rank",
+      "sourceFileTitle": "uk_sherman_vc_firefly_kit_3rank.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sherman_vc_firefly_kit_3rank.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_fiat_6614_firos": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_fiat_6614_firos.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_fiat_6614_firos",
+      "sourceFileTitle": "it_fiat_6614_firos.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_fiat_6614_firos.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flakpanzer_38t_Gepard": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_38t_gepard.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flakpanzer_38t_gepard",
+      "sourceFileTitle": "germ_flakpanzer_38t_gepard.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flakpanzer_38t_gepard.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_flarakrad": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flarakrad.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_flarakrad",
+      "sourceFileTitle": "germ_flarakrad.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_flarakrad.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_freccia_hitfist_ows": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_freccia_hitfist_ows.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_freccia_hitfist_ows",
+      "sourceFileTitle": "it_freccia_hitfist_ows.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_freccia_hitfist_ows.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_samp_t_launcher": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_samp_t_launcher.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_samp_t_launcher",
+      "sourceFileTitle": "fr_samp_t_launcher.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_samp_t_launcher.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_samp_t_fcs": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_samp_t_fcs.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_samp_t_fcs",
+      "sourceFileTitle": "fr_samp_t_fcs.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_samp_t_fcs.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_samp_t_fcs": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_samp_t_fcs.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_samp_t_fcs",
+      "sourceFileTitle": "it_samp_t_fcs.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_samp_t_fcs.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_g6_spg": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_g6_spg.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_g6_spg",
+      "sourceFileTitle": "uk_g6_spg.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_g6_spg.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_garford_putilov": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_garford_putilov.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_garford_putilov",
+      "sourceFileTitle": "germ_garford_putilov.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_garford_putilov.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_gaz_4m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_gaz_4m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_gaz_4m",
+      "sourceFileTitle": "ussr_gaz_4m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_gaz_4m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_gaz_dshk": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_gaz_dshk.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_gaz_dshk",
+      "sourceFileTitle": "ussr_gaz_dshk.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_gaz_dshk.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_vickers_gbt_155": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vickers_gbt_155.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_vickers_gbt_155",
+      "sourceFileTitle": "uk_vickers_gbt_155.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vickers_gbt_155.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_m113a1_tow": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_m113a1_tow.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_m113a1_tow",
+      "sourceFileTitle": "il_m113a1_tow.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_m113a1_tow.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_mk1_grant": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_mk1_grant.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_mk1_grant",
+      "sourceFileTitle": "uk_mk1_grant.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_mk1_grant.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_3_inch_gun_carrier": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_3_inch_gun_carrier.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_3_inch_gun_carrier",
+      "sourceFileTitle": "uk_3_inch_gun_carrier.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_3_inch_gun_carrier.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_hotchkiss_h35": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_hotchkiss_h35.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_hotchkiss_h35",
+      "sourceFileTitle": "fr_hotchkiss_h35.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_hotchkiss_h35.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_hotchkiss_h39": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_hotchkiss_h39.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_hotchkiss_h39",
+      "sourceFileTitle": "fr_hotchkiss_h39.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_hotchkiss_h39.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_hotchkiss_h39_cambronne": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_hotchkiss_h39_cambronne.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_hotchkiss_h39_cambronne",
+      "sourceFileTitle": "fr_hotchkiss_h39_cambronne.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_hotchkiss_h39_cambronne.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_95_ha_go": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_95_ha_go.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_95_ha_go",
+      "sourceFileTitle": "jp_type_95_ha_go.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_95_ha_go.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_95_ha_go_commander": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_95_ha_go_commander.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_95_ha_go_commander",
+      "sourceFileTitle": "jp_type_95_ha_go_commander.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_95_ha_go_commander.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a25_mk_8": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a25_mk_8.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a25_mk_8",
+      "sourceFileTitle": "uk_a25_mk_8.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a25_mk_8.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_2_ho_i": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_2_ho_i.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_2_ho_i",
+      "sourceFileTitle": "jp_type_2_ho_i.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_2_ho_i.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_2_ho_ni_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_2_ho_ni_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_2_ho_ni_2",
+      "sourceFileTitle": "jp_type_2_ho_ni_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_2_ho_ni_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_3_ho_ni_III": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_3_ho_ni_iii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_3_ho_ni_iii",
+      "sourceFileTitle": "jp_type_3_ho_ni_iii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_3_ho_ni_iii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_5_ho_ri_production": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_5_ho_ri_production.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_5_ho_ri_production",
+      "sourceFileTitle": "jp_type_5_ho_ri_production.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_5_ho_ri_production.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_5_ho_ri_prototype": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_5_ho_ri_prototype.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_5_ho_ri_prototype",
+      "sourceFileTitle": "jp_type_5_ho_ri_prototype.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_5_ho_ri_prototype.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_4_ho_ro": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_4_ho_ro.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_4_ho_ro",
+      "sourceFileTitle": "jp_type_4_ho_ro.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_4_ho_ro.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_m163_vulcan": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_m163_vulcan.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_m163_vulcan",
+      "sourceFileTitle": "il_m163_vulcan.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_m163_vulcan.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_hstv_l": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_hstv_l.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_hstv_l",
+      "sourceFileTitle": "us_hstv_l.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_hstv_l.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_icv_ifv_prototype": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_icv_ifv_prototype.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_icv_ifv_prototype",
+      "sourceFileTitle": "jp_icv_ifv_prototype.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_icv_ifv_prototype.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_ikv_91_105": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_ikv_91_105.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_ikv_91_105",
+      "sourceFileTitle": "sw_ikv_91_105.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_ikv_91_105.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a1e1_independent": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a1e1_independent.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a1e1_independent",
+      "sourceFileTitle": "uk_a1e1_independent.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a1e1_independent.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_iris_slm_launcher": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_iris_slm_launcher.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_iris_slm_launcher",
+      "sourceFileTitle": "germ_iris_slm_launcher.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_iris_slm_launcher.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_iris_slm_fcs": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_iris_slm_fcs.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_iris_slm_fcs",
+      "sourceFileTitle": "germ_iris_slm_fcs.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_iris_slm_fcs.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_is_2_1944_revenge": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_2_1944_revenge.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_is_2_1944_revenge",
+      "sourceFileTitle": "ussr_is_2_1944_revenge.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_is_2_1944_revenge.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_is_2_1943_no402": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_is_2_1943_no402.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_is_2_1943_no402",
+      "sourceFileTitle": "cn_is_2_1943_no402.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_is_2_1943_no402.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_it_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_it_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_it_1",
+      "sourceFileTitle": "ussr_it_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_it_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_semovente_m43_75_bersaglieri": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m43_75_34.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_semovente_m43_75_34",
+      "sourceFileTitle": "it_semovente_m43_75_34.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_semovente_m43_75_34.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_crotale_ng": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_crotale_ng.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_crotale_ng",
+      "sourceFileTitle": "sw_crotale_ng.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_crotale_ng.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_crotale_ng": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_crotale_ng.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_crotale_ng",
+      "sourceFileTitle": "fr_crotale_ng.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_crotale_ng.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_itpsv_90": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_itpsv_90.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_itpsv_90",
+      "sourceFileTitle": "sw_itpsv_90.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_itpsv_90.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_jaguar_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_jaguar_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_jaguar_2",
+      "sourceFileTitle": "germ_jaguar_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_jaguar_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sk105_a2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sk105_a2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sk105_a2",
+      "sourceFileTitle": "germ_sk105_a2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sk105_a2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_2_ka_mi": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_2_ka_mi.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_2_ka_mi",
+      "sourceFileTitle": "jp_type_2_ka_mi.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_2_ka_mi.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_kf_41": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_kf_41.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_kf_41",
+      "sourceFileTitle": "it_kf_41.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_kf_41.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_l3_cc": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_l3_cc.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_l3_cc",
+      "sourceFileTitle": "it_l3_cc.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_l3_cc.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_l6": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_l6.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_l6",
+      "sourceFileTitle": "it_l6.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_l6.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_l6_leone": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_l6_leone.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_l6_leone",
+      "sourceFileTitle": "it_l6_leone.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_l6_leone.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_lancia3ro_100": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_lancia3ro_100.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_lancia3ro_100",
+      "sourceFileTitle": "it_lancia3ro_100.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_lancia3ro_100.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_leclerc_s1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leclerc_s1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_leclerc_s1",
+      "sourceFileTitle": "fr_leclerc_s1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leclerc_s1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_leopard_1a5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_leopard_1a5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_leopard_1a5",
+      "sourceFileTitle": "it_leopard_1a5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_leopard_1a5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_leopard_2a4_fin": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_leopard_2a4_fin.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_leopard_2a4_fin",
+      "sourceFileTitle": "sw_leopard_2a4_fin.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_leopard_2a4_fin.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_leopard_2a4nl": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leopard_2a4nl.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_leopard_2a4nl",
+      "sourceFileTitle": "fr_leopard_2a4nl.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leopard_2a4nl.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2a5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2a5",
+      "sourceFileTitle": "germ_leopard_2a5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_leopard_2a5nl": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leopard_2a5nl.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_leopard_2a5nl",
+      "sourceFileTitle": "fr_leopard_2a5nl.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_leopard_2a5nl.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_vickers_mk_6_aa_mk_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vickers_mk_6_aa_mk_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_vickers_mk_6_aa_mk_1",
+      "sourceFileTitle": "uk_vickers_mk_6_aa_mk_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vickers_mk_6_aa_mk_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_lorraine_155": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_lorraine_155.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_lorraine_155",
+      "sourceFileTitle": "fr_lorraine_155.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_lorraine_155.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_lorraine_37l": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_lorraine_37l.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_lorraine_37l",
+      "sourceFileTitle": "fr_lorraine_37l.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_lorraine_37l.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_losat_ccv": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_losat_ccv.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_losat_ccv",
+      "sourceFileTitle": "us_losat_ccv.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_losat_ccv.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_lvkv_90c": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_lvkv_90c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_lvkv_90c",
+      "sourceFileTitle": "sw_lvkv_90c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_lvkv_90c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_lvrbv_701": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_lvrbv_701.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_lvrbv_701",
+      "sourceFileTitle": "sw_lvrbv_701.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_lvrbv_701.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_lvt_a_4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_lvt_a_4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_lvt_a_4",
+      "sourceFileTitle": "us_lvt_a_4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_lvt_a_4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_lvt_4_zis_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_lvt_4_zis_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_lvt_4_zis_2",
+      "sourceFileTitle": "us_lvt_4_zis_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_lvt_4_zis_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_lvt_4_zis_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_lvt_4_zis_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_lvt_4_zis_2",
+      "sourceFileTitle": "cn_lvt_4_zis_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_lvt_4_zis_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_lvt_bofors": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_lvt_bofors.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_lvt_bofors",
+      "sourceFileTitle": "fr_lvt_bofors.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_lvt_bofors.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m103": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m103.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m103",
+      "sourceFileTitle": "us_m103.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m103.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m11_39": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m11_39.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m11_39",
+      "sourceFileTitle": "it_m11_39.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m11_39.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m113a1_tow": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m113a1_tow.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m113a1_tow",
+      "sourceFileTitle": "it_m113a1_tow.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m113a1_tow.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_halftrack_m13": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_halftrack_m13.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_halftrack_m13",
+      "sourceFileTitle": "us_halftrack_m13.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_halftrack_m13.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m13_40_serie_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m13_40_serie_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m13_40_serie_2",
+      "sourceFileTitle": "it_m13_40_serie_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m13_40_serie_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m13_40_serie_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m13_40_serie_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m13_40_serie_3",
+      "sourceFileTitle": "it_m13_40_serie_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m13_40_serie_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m14_41": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m14_41.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m14_41",
+      "sourceFileTitle": "it_m14_41.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m14_41.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m14_41_47_40": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m14_41_47_40.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m14_41_47_40",
+      "sourceFileTitle": "it_m14_41_47_40.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m14_41_47_40.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_halftrack_m15": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_halftrack_m15.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_halftrack_m15",
+      "sourceFileTitle": "us_halftrack_m15.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_halftrack_m15.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m15_42": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m15_42.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m15_42",
+      "sourceFileTitle": "it_m15_42.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m15_42.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m163_vulcan": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m163_vulcan.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m163_vulcan",
+      "sourceFileTitle": "us_m163_vulcan.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m163_vulcan.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_m163_vulcan": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m163_vulcan.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_m163_vulcan",
+      "sourceFileTitle": "jp_m163_vulcan.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m163_vulcan.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_m19": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m19.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_m19",
+      "sourceFileTitle": "jp_m19.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m19.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1a1_aim_abrams": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a1_aim_abrams.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1a1_aim_abrams",
+      "sourceFileTitle": "us_m1a1_aim_abrams.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a1_aim_abrams.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m24_chaffee_tl": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m24_chaffee_tl.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m24_chaffee_tl",
+      "sourceFileTitle": "us_m24_chaffee_tl.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m24_chaffee_tl.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m2a2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m2a2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m2a2",
+      "sourceFileTitle": "us_m2a2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m2a2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_m3c": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_m3c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_m3c",
+      "sourceFileTitle": "ussr_m3c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_m3c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m3a1_stuart_usmc": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m3a1_stuart_usmc.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m3a1_stuart_usmc",
+      "sourceFileTitle": "us_m3a1_stuart_usmc.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m3a1_stuart_usmc.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m3a3_stuart": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m3a3_stuart.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m3a3_stuart",
+      "sourceFileTitle": "fr_m3a3_stuart.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m3a3_stuart.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4_sherman_promo": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4_sherman_promo.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4_sherman_promo",
+      "sourceFileTitle": "us_m4_sherman_promo.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4_sherman_promo.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m_41d": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m_41d.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m_41d",
+      "sourceFileTitle": "cn_m_41d.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m_41d.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m44": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m44.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m44",
+      "sourceFileTitle": "it_m44.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m44.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_m44": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_m44.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_m44",
+      "sourceFileTitle": "uk_m44.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_m44.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_m47_patton_II": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m47_patton_ii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_m47_patton_ii",
+      "sourceFileTitle": "jp_m47_patton_ii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_m47_patton_ii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a2_1944": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a2_1944_germ.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a2_1944_germ",
+      "sourceFileTitle": "us_m4a2_1944_germ.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a2_1944_germ.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_m4a3e2_sherman_jumbo": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m4a3e2_sherman_jumbo.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_m4a3e2_sherman_jumbo",
+      "sourceFileTitle": "fr_m4a3e2_sherman_jumbo.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_m4a3e2_sherman_jumbo.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m4a5_ram_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a5_ram_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m4a5_ram_2",
+      "sourceFileTitle": "us_m4a5_ram_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m4a5_ram_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m551_76": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m551_76.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m551_76",
+      "sourceFileTitle": "us_m551_76.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m551_76.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m5a1_stuart_td": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m5a1_stuart_td.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m5a1_stuart_td",
+      "sourceFileTitle": "us_m5a1_stuart_td.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m5a1_stuart_td.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m60a3_slep": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60a3_slep.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m60a3_slep",
+      "sourceFileTitle": "us_m60a3_slep.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60a3_slep.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_m60a1_ariete": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_m60a1_ariete.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_m60a1_ariete",
+      "sourceFileTitle": "it_m60a1_ariete.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_m60a1_ariete.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m60a1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60a1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m60a1",
+      "sourceFileTitle": "us_m60a1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m60a1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m728": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m728.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m728",
+      "sourceFileTitle": "us_m728.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m728.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m8_scott": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m8_scott.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m8_scott",
+      "sourceFileTitle": "us_m8_scott.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m8_scott.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m8_greyhound": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m8_greyhound.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m8_greyhound",
+      "sourceFileTitle": "us_m8_greyhound.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m8_greyhound.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m901_itv": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m901_itv.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m901_itv",
+      "sourceFileTitle": "us_m901_itv.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m901_itv.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_machbet": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_machbet.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_machbet",
+      "sourceFileTitle": "il_machbet.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_machbet.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_magach_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_magach_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_magach_3",
+      "sourceFileTitle": "us_magach_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_magach_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_3",
+      "sourceFileTitle": "il_magach_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_6": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_6",
+      "sourceFileTitle": "il_magach_6.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_6b_gal": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6b_gal.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_6b_gal",
+      "sourceFileTitle": "il_magach_6b_gal.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6b_gal.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_6m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_6m",
+      "sourceFileTitle": "il_magach_6m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_6r": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6r.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_6r",
+      "sourceFileTitle": "il_magach_6r.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6r.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_magach_6_rocket": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6_rocket.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_magach_6_rocket",
+      "sourceFileTitle": "il_magach_6_rocket.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_magach_6_rocket.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_marder_1a3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_marder_1a3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_marder_1a3",
+      "sourceFileTitle": "germ_marder_1a3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_marder_1a3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_marder_1a1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_marder_1a1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_marder_1a1",
+      "sourceFileTitle": "germ_marder_1a1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_marder_1a1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_mark_v": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_mark_v.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_mark_v",
+      "sourceFileTitle": "uk_mark_v.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_mark_v.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_merkava_mk_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_merkava_mk_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_merkava_mk_1",
+      "sourceFileTitle": "us_merkava_mk_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_merkava_mk_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_merkava_mk_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_merkava_mk_1",
+      "sourceFileTitle": "il_merkava_mk_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_merkava_mk_2b_late": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_merkava_mk_2b_late.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_merkava_mk_2b_late",
+      "sourceFileTitle": "us_merkava_mk_2b_late.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_merkava_mk_2b_late.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_merkava_mk_3d": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_merkava_mk_3d.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_merkava_mk_3d",
+      "sourceFileTitle": "us_merkava_mk_3d.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_merkava_mk_3d.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_merkava_mk_4_lic": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_4_lic.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_merkava_mk_4_lic",
+      "sourceFileTitle": "il_merkava_mk_4_lic.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_merkava_mk_4_lic.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_a_12_mk_2_matilda_2A_F96": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_a_12_mk_2_matilda_2a_f96.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_a_12_mk_2_matilda_2a_f96",
+      "sourceFileTitle": "ussr_a_12_mk_2_matilda_2a_f96.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_a_12_mk_2_matilda_2a_f96.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_mkpz_m47": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_mkpz_m47.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_mkpz_m47",
+      "sourceFileTitle": "germ_mkpz_m47.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_mkpz_m47.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_namer_rcws_30": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_namer_rcws_30.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_namer_rcws_30",
+      "sourceFileTitle": "il_namer_rcws_30.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_namer_rcws_30.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_namer_tsrikhon": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_namer_tsrikhon.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_namer_tsrikhon",
+      "sourceFileTitle": "il_namer_tsrikhon.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_namer_tsrikhon.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_nasams_fcs": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_nasams_fcs.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_nasams_fcs",
+      "sourceFileTitle": "sw_nasams_fcs.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_nasams_fcs.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_object_122tm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_object_122tm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_object_122tm",
+      "sourceFileTitle": "cn_object_122tm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_object_122tm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_object_211": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_object_211.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_object_211",
+      "sourceFileTitle": "cn_object_211.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_object_211.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_olifant_mk_1a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_olifant_mk_1a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_olifant_mk_1a",
+      "sourceFileTitle": "uk_olifant_mk_1a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_olifant_mk_1a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_9a33bm2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_9a33bm2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_9a33bm2",
+      "sourceFileTitle": "uk_9a33bm2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_9a33bm2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_9a33bm3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_9a33bm3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_9a33bm3",
+      "sourceFileTitle": "it_9a33bm3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_9a33bm3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_citroen_kegresse_p4t": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_citroen_kegresse_p4t.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_citroen_kegresse_p4t",
+      "sourceFileTitle": "fr_citroen_kegresse_p4t.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_citroen_kegresse_p4t.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_p_40": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_p_40.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_p_40",
+      "sourceFileTitle": "it_p_40.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_p_40.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_panzerjager_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerjager_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_panzerjager_1",
+      "sourceFileTitle": "germ_panzerjager_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_panzerjager_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pbv_301": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pbv_301.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pbv_301",
+      "sourceFileTitle": "sw_pbv_301.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pbv_301.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pbv_302_bill": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pbv_302_bill.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pbv_302_bill",
+      "sourceFileTitle": "sw_pbv_302_bill.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pbv_302_bill.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_pgz_04a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_pgz_04a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_pgz_04a",
+      "sourceFileTitle": "cn_pgz_04a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_pgz_04a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_65_aa": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_65_aa.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_65_aa",
+      "sourceFileTitle": "cn_type_65_aa.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_65_aa.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_type_65_aa": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_type_65_aa.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_type_65_aa",
+      "sourceFileTitle": "ussr_type_65_aa.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_type_65_aa.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_plz_83": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_plz_83.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_plz_83",
+      "sourceFileTitle": "cn_plz_83.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_plz_83.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_plz_83_130": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_plz_83_130.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_plz_83_130",
+      "sourceFileTitle": "cn_plz_83_130.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_plz_83_130.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2_pt14": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2_pt14.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2_pt14",
+      "sourceFileTitle": "germ_leopard_2_pt14.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2_pt14.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_pt_76_57": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_pt_76_57.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_pt_76_57",
+      "sourceFileTitle": "ussr_pt_76_57.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_pt_76_57.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ptl_02": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ptl_02.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ptl_02",
+      "sourceFileTitle": "cn_ptl_02.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ptl_02.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_schutzenpanzer_puma": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_schutzenpanzer_puma.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_schutzenpanzer_puma",
+      "sourceFileTitle": "germ_schutzenpanzer_puma.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_schutzenpanzer_puma.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_schutzenpanzer_puma_vjtf": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_schutzenpanzer_puma_vjtf.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_schutzenpanzer_puma_vjtf",
+      "sourceFileTitle": "germ_schutzenpanzer_puma_vjtf.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_schutzenpanzer_puma_vjtf.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pvlvv_fm42": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvlvv_fm42.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pvlvv_fm42",
+      "sourceFileTitle": "sw_pvlvv_fm42.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvlvv_fm42.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_pvrbv_551": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvrbv_551.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_pvrbv_551",
+      "sourceFileTitle": "sw_pvrbv_551.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_pvrbv_551.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_38t_ausf_F": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_38t_ausf_f.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_38t_ausf_f",
+      "sourceFileTitle": "germ_pzkpfw_38t_ausf_f.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_38t_ausf_f.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_II_ausf_C_td": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_ii_ausf_c_td.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_ii_ausf_c_td",
+      "sourceFileTitle": "germ_pzkpfw_ii_ausf_c_td.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_ii_ausf_c_td.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_III_ausf_J_td": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_j_td.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iii_ausf_j_td",
+      "sourceFileTitle": "germ_pzkpfw_iii_ausf_j_td.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_j_td.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_III_ausf_B": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_iii_ausf_b",
+      "sourceFileTitle": "germ_pzkpfw_iii_ausf_b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_iii_ausf_b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_II_ausf_C": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_ii_ausf_c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_ii_ausf_c",
+      "sourceFileTitle": "germ_pzkpfw_ii_ausf_c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_ii_ausf_c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_II_ausf_F": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_ii_ausf_f.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_ii_ausf_f",
+      "sourceFileTitle": "germ_pzkpfw_ii_ausf_f.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_ii_ausf_f.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_II_ausf_C_DAK": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_ii_ausf_c_dak.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_ii_ausf_c_dak",
+      "sourceFileTitle": "germ_pzkpfw_ii_ausf_c_dak.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_ii_ausf_c_dak.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_amd_35_kwk": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_amd_35_kwk.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_amd_35_kwk",
+      "sourceFileTitle": "germ_amd_35_kwk.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_amd_35_kwk.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_amd_35_kwk39": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_amd_35_kwk39.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_amd_35_kwk39",
+      "sourceFileTitle": "germ_amd_35_kwk39.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_amd_35_kwk39.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_qn506": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_qn506.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_qn506",
+      "sourceFileTitle": "cn_qn506.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_qn506.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_renault_r39": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_renault_r39.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_renault_r39",
+      "sourceFileTitle": "fr_renault_r39.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_renault_r39.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_oto_r3_t20_fa": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_oto_r3_t20_fa.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_oto_r3_t20_fa",
+      "sourceFileTitle": "it_oto_r3_t20_fa.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_oto_r3_t20_fa.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_raketenjagdpanzer_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_raketenjagdpanzer_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_raketenjagdpanzer_2",
+      "sourceFileTitle": "germ_raketenjagdpanzer_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_raketenjagdpanzer_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_raketenjagdpanzer_2_hot": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_raketenjagdpanzer_2_hot.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_raketenjagdpanzer_2_hot",
+      "sourceFileTitle": "germ_raketenjagdpanzer_2_hot.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_raketenjagdpanzer_2_hot.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_cruiser_ram_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_cruiser_ram_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_cruiser_ram_1",
+      "sourceFileTitle": "uk_cruiser_ram_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_cruiser_ram_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_m4a5_ram_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_m4a5_ram_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_m4a5_ram_2",
+      "sourceFileTitle": "uk_m4a5_ram_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_m4a5_ram_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_tracked_rapier": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_tracked_rapier.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_tracked_rapier",
+      "sourceFileTitle": "uk_tracked_rapier.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_tracked_rapier.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_ratel_20": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ratel_20.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_ratel_20",
+      "sourceFileTitle": "uk_ratel_20.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ratel_20.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_rbt_5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_rbt_5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_rbt_5",
+      "sourceFileTitle": "ussr_rbt_5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_rbt_5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_95_heavy": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_95_heavy.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_95_heavy",
+      "sourceFileTitle": "jp_type_95_heavy.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_95_heavy.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_hiro_sha": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_hiro_sha.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_hiro_sha",
+      "sourceFileTitle": "jp_hiro_sha.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_hiro_sha.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_30_roland": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_roland.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_30_roland",
+      "sourceFileTitle": "fr_amx_30_roland.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_30_roland.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_rooikat_76": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_rooikat_76.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_rooikat_76",
+      "sourceFileTitle": "uk_rooikat_76.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_rooikat_76.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_rooikat_mttd": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_rooikat_mttd.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_rooikat_mttd",
+      "sourceFileTitle": "uk_rooikat_mttd.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_rooikat_mttd.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_somua_s35": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_somua_s35.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_somua_s35",
+      "sourceFileTitle": "fr_somua_s35.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_somua_s35.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_sarc_mk4_a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sarc_mk4_a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_sarc_mk4_a",
+      "sourceFileTitle": "uk_sarc_mk4_a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_sarc_mk4_a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_marmon_herrington_mk_6_6pdr": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_marmon_herrington_mk_6_6pdr.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_marmon_herrington_mk_6_6pdr",
+      "sourceFileTitle": "uk_marmon_herrington_mk_6_6pdr.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_marmon_herrington_mk_6_6pdr.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_somua_sau40": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_somua_sau40.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_somua_sau40",
+      "sourceFileTitle": "fr_somua_sau40.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_somua_sau40.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_6_2_flak36": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_6_2_flak36.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_6_2_flak36",
+      "sourceFileTitle": "germ_sdkfz_6_2_flak36.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_6_2_flak36.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_221_s_pz_b_41": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_221_s_pz_b_41.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_221_s_pz_b_41",
+      "sourceFileTitle": "germ_sdkfz_221_s_pz_b_41.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_221_s_pz_b_41.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_222": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_222.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_222",
+      "sourceFileTitle": "germ_sdkfz_222.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_222.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_234_2_td": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_234_2_td.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_234_2_td",
+      "sourceFileTitle": "germ_sdkfz_234_2_td.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_234_2_td.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_234_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_234_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_234_3",
+      "sourceFileTitle": "germ_sdkfz_234_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_234_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_251_22": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_251_22.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_251_22",
+      "sourceFileTitle": "germ_sdkfz_251_22.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_251_22.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_sdkfz_251_9": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_251_9.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_sdkfz_251_9",
+      "sourceFileTitle": "germ_sdkfz_251_9.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_sdkfz_251_9.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_pzkpfw_38t_Aufklarungspanzer": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_38t_aufklarungspanzer.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_pzkpfw_38t_aufklarungspanzer",
+      "sourceFileTitle": "germ_pzkpfw_38t_aufklarungspanzer.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_pzkpfw_38t_aufklarungspanzer.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_sherman_vc_firefly": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_sherman_vc_firefly.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_sherman_vc_firefly",
+      "sourceFileTitle": "it_sherman_vc_firefly.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_sherman_vc_firefly.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_centurion_shot_kal_alef": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_centurion_shot_kal_alef.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_centurion_shot_kal_alef",
+      "sourceFileTitle": "il_centurion_shot_kal_alef.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_centurion_shot_kal_alef.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_centurion_shot_kal_d": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_shot_kal_d.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_centurion_shot_kal_d",
+      "sourceFileTitle": "uk_centurion_shot_kal_d.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_shot_kal_d.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_centurion_shot_kal_gimel": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_centurion_shot_kal_gimel.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_centurion_shot_kal_gimel",
+      "sourceFileTitle": "il_centurion_shot_kal_gimel.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_centurion_shot_kal_gimel.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_9p149": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_9p149.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_9p149",
+      "sourceFileTitle": "ussr_9p149.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_9p149.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_otobreda_sidam_25_mistral": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_otobreda_sidam_25_mistral.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_otobreda_sidam_25_mistral",
+      "sourceFileTitle": "it_otobreda_sidam_25_mistral.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_otobreda_sidam_25_mistral.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_skink_aa": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_skink_aa.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_skink_aa",
+      "sourceFileTitle": "uk_skink_aa.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_skink_aa.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_skink_aa_kit_3rank": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_skink_aa_kit_3rank.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_skink_aa_kit_3rank",
+      "sourceFileTitle": "us_skink_aa_kit_3rank.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_skink_aa_kit_3rank.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_95_so_ki": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_95_so_ki.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_95_so_ki",
+      "sourceFileTitle": "jp_type_95_so_ki.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_95_so_ki.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_stormpjas_fm43_44": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_stormpjas_fm43_44.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_stormpjas_fm43_44",
+      "sourceFileTitle": "sw_stormpjas_fm43_44.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_stormpjas_fm43_44.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_spyder_aio": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_spyder_aio.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_spyder_aio",
+      "sourceFileTitle": "il_spyder_aio.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_spyder_aio.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_spz_12_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_spz_12_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_spz_12_3",
+      "sourceFileTitle": "germ_spz_12_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_spz_12_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_saint_chamond": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_saint_chamond.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_saint_chamond",
+      "sourceFileTitle": "fr_saint_chamond.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_saint_chamond.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_t17e2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_t17e2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_t17e2",
+      "sourceFileTitle": "uk_t17e2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_t17e2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_stingray": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_stingray.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_stingray",
+      "sourceFileTitle": "jp_stingray.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_stingray.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_stormer_air_defence": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_stormer_air_defence.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_stormer_air_defence",
+      "sourceFileTitle": "uk_stormer_air_defence.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_stormer_air_defence.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_stormer_hvm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_stormer_hvm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_stormer_hvm",
+      "sourceFileTitle": "uk_stormer_hvm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_stormer_hvm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strf_9056": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strf_9056.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strf_9056",
+      "sourceFileTitle": "sw_strf_9056.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strf_9056.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strf_90b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strf_90b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strf_90b",
+      "sourceFileTitle": "sw_strf_90b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strf_90b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_fv102_striker": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv102_striker.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_fv102_striker",
+      "sourceFileTitle": "uk_fv102_striker.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv102_striker.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_103_0": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_103_0.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_103_0",
+      "sourceFileTitle": "sw_strv_103_0.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_103_0.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_103a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_103a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_103a",
+      "sourceFileTitle": "sw_strv_103a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_103a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_103c": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_103c.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_103c",
+      "sourceFileTitle": "sw_strv_103c.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_103c.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_104": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_104.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_104",
+      "sourceFileTitle": "sw_strv_104.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_104.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_105": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_105.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_105",
+      "sourceFileTitle": "sw_strv_105.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_105.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_121": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_121.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_121",
+      "sourceFileTitle": "sw_strv_121.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_121.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_81_rb52": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_3_ss11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_81_rb52",
+      "sourceFileTitle": "uk_centurion_mk_3_ss11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_3_ss11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_centurion_mk_3_ss11": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_3_ss11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_centurion_mk_3_ss11",
+      "sourceFileTitle": "uk_centurion_mk_3_ss11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_centurion_mk_3_ss11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_strv_m41_s1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m41_s1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_strv_m41_s1",
+      "sourceFileTitle": "sw_strv_m41_s1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_strv_m41_s1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m5a1_stuart_canadian_5st_arm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m5a1_stuart_canadian_5st_arm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m5a1_stuart_canadian_5st_arm",
+      "sourceFileTitle": "us_m5a1_stuart_canadian_5st_arm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m5a1_stuart_canadian_5st_arm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_100Y": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_100y.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_100y",
+      "sourceFileTitle": "ussr_su_100y.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_100y.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_57b": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_57b.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_57b",
+      "sourceFileTitle": "ussr_su_57b.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_57b.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_76d": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_76d.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_76d",
+      "sourceFileTitle": "ussr_su_76d.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_76d.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_76m_5st_kav_corps": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_76m_5st_kav_corps.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_76m_5st_kav_corps",
+      "sourceFileTitle": "ussr_su_76m_5st_kav_corps.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_76m_5st_kav_corps.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_su_85a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_85a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_su_85a",
+      "sourceFileTitle": "ussr_su_85a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_su_85a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_boxer_swatrinf": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_boxer_swatrinf.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_boxer_swatrinf",
+      "sourceFileTitle": "germ_boxer_swatrinf.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_boxer_swatrinf.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_10a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_10a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_10a",
+      "sourceFileTitle": "ussr_t_10a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_10a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_t_26_no531": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_26_no531.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_t_26_no531",
+      "sourceFileTitle": "cn_t_26_no531.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_26_no531.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_vickers_mk_e_45": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_vickers_mk_e_45.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_vickers_mk_e_45",
+      "sourceFileTitle": "sw_vickers_mk_e_45.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_vickers_mk_e_45.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_26E": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_26e.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_26e",
+      "sourceFileTitle": "ussr_t_26e.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_26e.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_26_1940_1st_GvTBr": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_26_1940_1st_gvtbr.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_26_1940_1st_gvtbr",
+      "sourceFileTitle": "ussr_t_26_1940_1st_gvtbr.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_26_1940_1st_gvtbr.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_34_1940_l_11": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_1940_l_11.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_34_1940_l_11",
+      "sourceFileTitle": "ussr_t_34_1940_l_11.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_34_1940_l_11.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_t_50_fin": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_50_fin.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_t_50_fin",
+      "sourceFileTitle": "sw_t_50_fin.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_t_50_fin.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_60_1941": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_60_1941.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_60_1941",
+      "sourceFileTitle": "ussr_t_60_1941.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_60_1941.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_69_2g": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_69_2g.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_69_2g",
+      "sourceFileTitle": "cn_type_69_2g.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_69_2g.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_70_1942": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_70_1942.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_70_1942",
+      "sourceFileTitle": "ussr_t_70_1942.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_70_1942.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_pzkpfw_III_ausf_J_L42": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_pzkpfw_iii_ausf_j_l42.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_pzkpfw_iii_ausf_j_l42",
+      "sourceFileTitle": "ussr_pzkpfw_iii_ausf_j_l42.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_pzkpfw_iii_ausf_j_l42.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_98_ta_se": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_98_ta_se.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_98_ta_se",
+      "sourceFileTitle": "jp_type_98_ta_se.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_98_ta_se.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_81_tansam_launcher": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_81_tansam_launcher.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_81_tansam_launcher",
+      "sourceFileTitle": "jp_type_81_tansam_launcher.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_81_tansam_launcher.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_81_tansam_fcs": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_81_tansam_fcs.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_81_tansam_fcs",
+      "sourceFileTitle": "jp_type_81_tansam_fcs.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_81_tansam_fcs.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_tiran_6": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_tiran_6.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_tiran_6",
+      "sourceFileTitle": "il_tiran_6.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_tiran_6.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_tog_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_tog_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_tog_2",
+      "sourceFileTitle": "uk_tog_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_tog_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_toldi_II_a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_toldi_ii_a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_toldi_ii_a",
+      "sourceFileTitle": "it_toldi_ii_a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_toldi_ii_a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_a39_tortoise": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a39_tortoise.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_a39_tortoise",
+      "sourceFileTitle": "uk_a39_tortoise.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_a39_tortoise.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_tor_m1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_tor_m1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_tor_m1",
+      "sourceFileTitle": "ussr_tor_m1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_tor_m1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_tpk_641_vpc": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_tpk_641_vpc.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_tpk_641_vpc",
+      "sourceFileTitle": "fr_tpk_641_vpc.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_tpk_641_vpc.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_40m_turan_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_40m_turan_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_40m_turan_1",
+      "sourceFileTitle": "it_40m_turan_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_40m_turan_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_03_chusam_fcs": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_03_chusam_fcs.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_03_chusam_fcs",
+      "sourceFileTitle": "jp_type_03_chusam_fcs.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_03_chusam_fcs.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_60_atm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_60_atm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_60_atm",
+      "sourceFileTitle": "jp_type_60_atm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_60_atm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_60_sprg": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_60_sprg.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_60_sprg",
+      "sourceFileTitle": "jp_type_60_sprg.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_60_sprg.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_61_mod": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_61_mod.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_61_mod",
+      "sourceFileTitle": "jp_type_61_mod.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_61_mod.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_type_62": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_type_62.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_type_62",
+      "sourceFileTitle": "ussr_type_62.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_type_62.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_62": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_62.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_62",
+      "sourceFileTitle": "cn_type_62.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_62.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_69": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_69.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_69",
+      "sourceFileTitle": "cn_type_69.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_69.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_69_2a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_69_2a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_69_2a",
+      "sourceFileTitle": "cn_type_69_2a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_69_2a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_74_mod_g_kai": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_74_mod_g_kai.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_74_mod_g_kai",
+      "sourceFileTitle": "jp_type_74_mod_g_kai.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_74_mod_g_kai.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_75_mlrs": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_75_mlrs.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_75_mlrs",
+      "sourceFileTitle": "jp_type_75_mlrs.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_75_mlrs.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "jp_type_94": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_94.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/jp_type_94",
+      "sourceFileTitle": "jp_type_94.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/jp_type_94.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_udes_33": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_udes_33.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_udes_33",
+      "sourceFileTitle": "sw_udes_33.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_udes_33.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_challenger_II": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_ii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_challenger_ii",
+      "sourceFileTitle": "uk_challenger_ii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_ii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m551_football": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m551.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m551",
+      "sourceFileTitle": "us_m551.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m551.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_m551_football": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_55a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_55a",
+      "sourceFileTitle": "ussr_t_55a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_55a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_valentine_mk_1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_valentine_mk_1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_valentine_mk_1",
+      "sourceFileTitle": "uk_valentine_mk_1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_valentine_mk_1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_vbc_pt2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_vbc_pt2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_vbc_pt2",
+      "sourceFileTitle": "it_vbc_pt2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_vbc_pt2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_vbci": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_vbci.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_vbci",
+      "sourceFileTitle": "fr_vbci.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_vbci.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_vbci2_mct30": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_vbci2_mct30.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_vbci2_mct30",
+      "sourceFileTitle": "fr_vbci2_mct30.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_vbci2_mct30.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_vcc_80_hitfist_30": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_vcc_80_hitfist_30.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_vcc_80_hitfist_30",
+      "sourceFileTitle": "it_vcc_80_hitfist_30.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_vcc_80_hitfist_30.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_vextra_105": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_vextra_105.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_vextra_105",
+      "sourceFileTitle": "fr_vextra_105.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_vextra_105.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_vfm_5": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vfm_5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_vfm_5",
+      "sourceFileTitle": "uk_vfm_5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vfm_5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_vickers_mbt_mk_3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vickers_mbt_mk_3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_vickers_mbt_mk_3",
+      "sourceFileTitle": "uk_vickers_mbt_mk_3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vickers_mbt_mk_3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_vickers_mk7": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vickers_mk7.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_vickers_mk7",
+      "sourceFileTitle": "uk_vickers_mk7.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vickers_mk7.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_vickers_mk_e_37": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_vickers_mk_e_37.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_vickers_mk_e_37",
+      "sourceFileTitle": "sw_vickers_mk_e_37.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_vickers_mk_e_37.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "sw_k9_vidar": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/sw_k9_vidar.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/sw_k9_vidar",
+      "sourceFileTitle": "sw_k9_vidar.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/sw_k9_vidar.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_vijayanta": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vijayanta.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_vijayanta",
+      "sourceFileTitle": "uk_vijayanta.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_vijayanta.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_vt_1_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_vt_1_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_vt_1_2",
+      "sourceFileTitle": "germ_vt_1_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_vt_1_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "fr_amx_vtt_dca": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_vtt_dca.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/fr_amx_vtt_dca",
+      "sourceFileTitle": "fr_amx_vtt_dca.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/fr_amx_vtt_dca.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_fv510_isv": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv510_isv.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_fv510_isv",
+      "sourceFileTitle": "uk_fv510_isv.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_fv510_isv.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_wma_301": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_wma_301.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_wma_301",
+      "sourceFileTitle": "cn_wma_301.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_wma_301.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_wz_141": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_wz_141.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_wz_141",
+      "sourceFileTitle": "cn_wz_141.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_wz_141.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_xm1_chrysler": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm1_chrysler.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_xm1_chrysler",
+      "sourceFileTitle": "us_xm1_chrysler.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_xm1_chrysler.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_ss_11_halftrack": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_ss_11_halftrack.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_ss_11_halftrack",
+      "sourceFileTitle": "il_ss_11_halftrack.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_ss_11_halftrack.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_zbd_04a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_zbd_04a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_zbd_04a",
+      "sourceFileTitle": "cn_zbd_04a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_zbd_04a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_86": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_86.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_86",
+      "sourceFileTitle": "cn_type_86.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_86.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_zis_12_94KM_1945": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zis_12_94km_1945.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_zis_12_94km_1945",
+      "sourceFileTitle": "ussr_zis_12_94km_1945.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zis_12_94km_1945.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_zis_43": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zis_43.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_zis_43",
+      "sourceFileTitle": "ussr_zis_43.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zis_43.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_40_43m_zrinyi_2": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_40_43m_zrinyi_2.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_40_43m_zrinyi_2",
+      "sourceFileTitle": "it_40_43m_zrinyi_2.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_40_43m_zrinyi_2.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_ratel_zt3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ratel_zt3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_ratel_zt3",
+      "sourceFileTitle": "uk_ratel_zt3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_ratel_zt3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ztz_59a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_59a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ztz_59a",
+      "sourceFileTitle": "cn_ztz_59a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_59a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_59d": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_59d.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_59d",
+      "sourceFileTitle": "cn_type_59d.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_59d.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_ztz_96a": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_96a.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_ztz_96a",
+      "sourceFileTitle": "cn_ztz_96a.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_ztz_96a.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_zut_37": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zut_37.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_zut_37",
+      "sourceFileTitle": "ussr_zut_37.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_zut_37.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_sdkfz_251_21_kit_3rank": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_sdkfz_251_21_kit_3rank.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_sdkfz_251_21_kit_3rank",
+      "sourceFileTitle": "ussr_sdkfz_251_21_kit_3rank.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_sdkfz_251_21_kit_3rank.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_garford_putilov": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_garford_putilov.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_garford_putilov",
+      "sourceFileTitle": "ussr_garford_putilov.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_garford_putilov.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_valentine_mk_9": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_valentine_mk_9.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_valentine_mk_9",
+      "sourceFileTitle": "uk_valentine_mk_9.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_valentine_mk_9.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_pantsyr_sm_sv": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_pantsyr_sm_sv.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_pantsyr_sm_sv",
+      "sourceFileTitle": "ussr_pantsyr_sm_sv.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_pantsyr_sm_sv.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_9a35_m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_9a35_m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_9a35_m",
+      "sourceFileTitle": "it_9a35_m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_9a35_m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_9a35_m": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_9a35_m.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_9a35_m",
+      "sourceFileTitle": "uk_9a35_m.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_9a35_m.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_t_62": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_62.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_t_62",
+      "sourceFileTitle": "cn_t_62.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_t_62.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_97_chi_ha": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_97_chi_ha.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_97_chi_ha",
+      "sourceFileTitle": "cn_type_97_chi_ha.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_97_chi_ha.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_type_97_kai": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_97_kai.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_type_97_kai",
+      "sourceFileTitle": "cn_type_97_kai.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_type_97_kai.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_isu_122": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_isu_122.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_isu_122",
+      "sourceFileTitle": "cn_isu_122.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_isu_122.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_isu_152": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_isu_152.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_isu_152",
+      "sourceFileTitle": "cn_isu_152.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_isu_152.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m113a1_tow": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m113a1_tow.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m113a1_tow",
+      "sourceFileTitle": "cn_m113a1_tow.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m113a1_tow.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m3a3_stuart_1st_ptg": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m3a3_stuart_1st_ptg.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m3a3_stuart_1st_ptg",
+      "sourceFileTitle": "cn_m3a3_stuart_1st_ptg.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m3a3_stuart_1st_ptg.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m3a3_stuart": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m3a3_stuart.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m3a3_stuart",
+      "sourceFileTitle": "cn_m3a3_stuart.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m3a3_stuart.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m5a1_stuart": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m5a1_stuart.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m5a1_stuart",
+      "sourceFileTitle": "cn_m5a1_stuart.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m5a1_stuart.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_m60a3_tts": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m60a3_tts.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_m60a3_tts",
+      "sourceFileTitle": "cn_m60a3_tts.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_m60a3_tts.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_pt_76": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_pt_76.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_pt_76",
+      "sourceFileTitle": "cn_pt_76.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_pt_76.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_sdkfz_222_early": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_sdkfz_222_early.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_sdkfz_222_early",
+      "sourceFileTitle": "cn_sdkfz_222_early.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_sdkfz_222_early.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_challenger_II_yt_cup_2019": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_ii.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_challenger_ii_yt_cup_2019",
+      "sourceFileTitle": "uk_challenger_ii.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_ii.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_leopard_2a5_yt_cup_2019": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a5.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_leopard_2a5_yt_cup_2019",
+      "sourceFileTitle": "germ_leopard_2a5.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_leopard_2a5.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_m1a1_abrams_yt_cup_2019": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a1_abrams_yt_cup_2019.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_m1a1_abrams_yt_cup_2019",
+      "sourceFileTitle": "us_m1a1_abrams_yt_cup_2019.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_m1a1_abrams_yt_cup_2019.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "ussr_t_80u_yt_cup_2019": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80u.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/ussr_t_80u_yt_cup_2019",
+      "sourceFileTitle": "ussr_t_80u.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/ussr_t_80u.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "germ_9a33bm3": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/germ_9a33bm3.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/germ_9a33bm3",
+      "sourceFileTitle": "germ_9a33bm3.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/germ_9a33bm3.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "us_lvt_a_1_trb": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/us_lvt_a_1_trb.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/us_lvt_a_1_trb",
+      "sourceFileTitle": "us_lvt_a_1_trb.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/us_lvt_a_1_trb.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "uk_challenger_2_megatron_sm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2_megatron_sm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/uk_challenger_2_megatron_sm",
+      "sourceFileTitle": "uk_challenger_2_megatron_sm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/uk_challenger_2_megatron_sm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "cn_mbt2000_sm": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/cn_mbt2000_sm.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/cn_mbt2000_sm",
+      "sourceFileTitle": "cn_mbt2000_sm.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/cn_mbt2000_sm.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "it_t_72m1": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/it_t_72m1.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/it_t_72m1",
+      "sourceFileTitle": "it_t_72m1.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/it_t_72m1.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_amx_13_75": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_amx_13_75.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_amx_13_75",
+      "sourceFileTitle": "il_amx_13_75.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_amx_13_75.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_mim_72_chaparral": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_mim_72_chaparral.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_mim_72_chaparral",
+      "sourceFileTitle": "il_mim_72_chaparral.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_mim_72_chaparral.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    },
+    "il_zsu_23_4": {
+      "imageUrl": "https://static.encyclopedia.warthunder.com/slots/il_zsu_23_4.png",
+      "sourcePage": "https://wiki.warthunder.com/unit/il_zsu_23_4",
+      "sourceFileTitle": "il_zsu_23_4.png",
+      "sourceUrl": "https://static.encyclopedia.warthunder.com/slots/il_zsu_23_4.png",
+      "attribution": "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+      "matchedBy": "exact unit id",
+      "confidence": "high"
+    }
+  },
+  "misses": [],
+  "stats": {
+    "totalGroundVehicles": 1191,
+    "matched": 1191,
+    "fallbacks": 0
+  }
+}

--- a/scripts/prepare-vehicle-images.mjs
+++ b/scripts/prepare-vehicle-images.mjs
@@ -1,0 +1,233 @@
+import fs from "fs";
+import https from "https";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const DATA_DIR = path.join(ROOT, "public", "data");
+const JOINED_CSV = path.join(DATA_DIR, "latest-joined.csv");
+const OUT_PATH = path.join(DATA_DIR, "vehicle-images.json");
+const WIKI_BASE = "https://wiki.warthunder.com";
+const GROUND_URL = `${WIKI_BASE}/ground`;
+const DISABLE_FETCH = process.env.WT_DISABLE_IMAGE_FETCH === "1";
+
+function getText(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(
+        url,
+        {
+          headers: {
+            "User-Agent": "wt-data-project.web image manifest prep (+https://github.com/zeoce/wt-data-project.web)"
+          }
+        },
+        response => {
+          if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+            getText(new URL(response.headers.location, url).toString()).then(resolve, reject);
+            return;
+          }
+          if (response.statusCode !== 200) {
+            reject(new Error(`GET ${url} returned ${response.statusCode}`));
+            response.resume();
+            return;
+          }
+          let body = "";
+          response.setEncoding("utf8");
+          response.on("data", chunk => {
+            body += chunk;
+          });
+          response.on("end", () => resolve(body));
+        }
+      )
+      .on("error", reject);
+  });
+}
+
+function parseCsv(csv) {
+  const lines = csv.trim().split(/\r?\n/);
+  const headers = parseCsvLine(lines.shift() || "");
+  return lines.map(line => {
+    const values = parseCsvLine(line);
+    const row = {};
+    headers.forEach((header, index) => {
+      row[header] = values[index] || "";
+    });
+    return row;
+  });
+}
+
+function parseCsvLine(line) {
+  const out = [];
+  let current = "";
+  let quoted = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char === "\"") {
+      if (quoted && line[i + 1] === "\"") {
+        current += "\"";
+        i++;
+      } else {
+        quoted = !quoted;
+      }
+    } else if (char === "," && !quoted) {
+      out.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  out.push(current);
+  return out;
+}
+
+function decodeHtml(value) {
+  return String(value || "")
+    .replace(/&#039;/g, "'")
+    .replace(/&quot;/g, "\"")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
+function normalize(value) {
+  return String(value || "").toLowerCase().replace(/[^a-z0-9а-яё]/gi, "");
+}
+
+function displayName(row) {
+  return (row.alt_name || row.wk_name || row.name || "").replace(/_/g, " ");
+}
+
+function sourceFileTitle(url) {
+  try {
+    return path.basename(new URL(url).pathname);
+  } catch {
+    return "";
+  }
+}
+
+function parseGroundImages(html) {
+  const byUnit = new Map();
+  const unitPattern = /data-unit-id="([^"]+)"[\s\S]{0,2000}?background-image:url\(&#039;([^&]+)&#039;\)/g;
+  let match;
+  while ((match = unitPattern.exec(html)) !== null) {
+    const unitId = decodeHtml(match[1]);
+    const imageUrl = decodeHtml(match[2]);
+    if (!byUnit.has(unitId) && imageUrl.includes("static.encyclopedia.warthunder.com/slots/")) {
+      byUnit.set(unitId, imageUrl);
+    }
+  }
+  return byUnit;
+}
+
+function buildSearchIndex(rows) {
+  const index = new Map();
+  for (const row of rows) {
+    const keys = [row.name, row.wk_name, row.alt_name, displayName(row)].map(normalize).filter(Boolean);
+    for (const key of keys) {
+      if (!index.has(key)) index.set(key, row.name);
+    }
+  }
+  return index;
+}
+
+async function main() {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+  if (!fs.existsSync(JOINED_CSV)) {
+    throw new Error("public/data/latest-joined.csv is missing. Run npm run prepare:data first.");
+  }
+
+  const rows = parseCsv(fs.readFileSync(JOINED_CSV, "utf8")).filter(row => row.cls === "Ground_vehicles");
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    source: {
+      name: "War Thunder Wiki",
+      groundPage: GROUND_URL,
+      cdn: "https://static.encyclopedia.warthunder.com",
+      note: "Best-effort manifest built from official War Thunder Wiki unit ids and CDN slot thumbnails. Images are referenced remotely, not mirrored into this repository."
+    },
+    images: {},
+    misses: [],
+    stats: {
+      totalGroundVehicles: rows.length,
+      matched: 0,
+      fallbacks: 0
+    }
+  };
+
+  if (DISABLE_FETCH) {
+    manifest.source.note += " Fetching was disabled with WT_DISABLE_IMAGE_FETCH=1.";
+    manifest.misses = rows.map(row => ({
+      id: row.name,
+      name: displayName(row),
+      reason: "image fetching disabled"
+    }));
+    manifest.stats.fallbacks = rows.length;
+    fs.writeFileSync(OUT_PATH, JSON.stringify(manifest, null, 2));
+    console.log(`Vehicle image fetch disabled. Wrote empty manifest to ${path.relative(ROOT, OUT_PATH)}.`);
+    return;
+  }
+
+  const groundHtml = await getText(GROUND_URL);
+  const wikiImages = parseGroundImages(groundHtml);
+  const searchIndex = buildSearchIndex(rows);
+
+  for (const row of rows) {
+    const unitCandidates = [row.name, row.wk_name].filter(Boolean);
+    let matchId = unitCandidates.find(candidate => wikiImages.has(candidate));
+    let matchedBy = matchId ? "exact unit id" : "";
+    let confidence = "high";
+
+    if (!matchId) {
+      const normalizedKeys = unitCandidates.concat([row.alt_name, displayName(row)]).map(normalize).filter(Boolean);
+      for (const [unitId] of wikiImages) {
+        if (normalizedKeys.includes(normalize(unitId))) {
+          matchId = unitId;
+          matchedBy = "normalized unit id";
+          confidence = "medium";
+          break;
+        }
+      }
+    }
+
+    if (!matchId) {
+      const nameKey = [row.alt_name, displayName(row), row.wk_name].map(normalize).find(key => searchIndex.get(key) === row.name);
+      if (nameKey && wikiImages.has(row.name)) {
+        matchId = row.name;
+        matchedBy = "normalized joined name";
+        confidence = "medium";
+      }
+    }
+
+    if (matchId) {
+      const imageUrl = wikiImages.get(matchId);
+      manifest.images[row.name] = {
+        imageUrl,
+        sourcePage: `${WIKI_BASE}/unit/${encodeURIComponent(matchId)}`,
+        sourceFileTitle: sourceFileTitle(imageUrl),
+        sourceUrl: imageUrl,
+        attribution: "War Thunder Wiki / Gaijin Games Kft. official wiki CDN thumbnail. Referenced remotely; not redistributed in this repository.",
+        matchedBy,
+        confidence
+      };
+    } else {
+      manifest.misses.push({
+        id: row.name,
+        name: displayName(row),
+        reason: "no matching official wiki slot thumbnail found"
+      });
+    }
+  }
+
+  manifest.stats.matched = Object.keys(manifest.images).length;
+  manifest.stats.fallbacks = manifest.misses.length;
+  fs.writeFileSync(OUT_PATH, JSON.stringify(manifest, null, 2));
+  console.log(`Vehicle images matched: ${manifest.stats.matched}`);
+  console.log(`Vehicle image fallbacks: ${manifest.stats.fallbacks}`);
+  console.log(`Wrote ${path.relative(ROOT, OUT_PATH)}`);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/app/ground-rb-panel.ts
+++ b/src/app/ground-rb-panel.ts
@@ -31,6 +31,33 @@ type SourceInfo = {
     latestJoined: Metadata;
 };
 
+type VehicleImage = {
+    imageUrl: string;
+    sourcePage: string;
+    sourceFileTitle: string;
+    sourceUrl: string;
+    attribution: string;
+    matchedBy: string;
+    confidence: "high" | "medium" | "low";
+};
+
+type VehicleImageManifest = {
+    generatedAt: string;
+    source: {
+        name: string;
+        groundPage: string;
+        cdn: string;
+        note: string;
+    };
+    images: { [name: string]: VehicleImage };
+    misses: Array<{ id: string; name: string; reason: string }>;
+    stats: {
+        totalGroundVehicles: number;
+        matched: number;
+        fallbacks: number;
+    };
+};
+
 type Filters = {
     nation: string;
     brMin: number;
@@ -53,6 +80,7 @@ export class GroundRbPanel {
     private rows: JoinedRow[] = [];
     private metadata: Metadata[];
     private sourceInfo: SourceInfo | null = null;
+    private imageManifest: VehicleImageManifest | null = null;
     private selected: JoinedRow | null = null;
     private compareNames: string[] = [];
     private favorites: string[] = [];
@@ -85,6 +113,7 @@ export class GroundRbPanel {
                 fetch("data/source-info.json").then(response => this.requireOk(response, "data/source-info.json")).then(response => response.json())
             ]);
             this.sourceInfo = sourceInfo;
+            this.imageManifest = await this.loadImageManifest();
             this.rows = this.parseCsv(csv)
                 .filter(row => row.cls === "Ground_vehicles")
                 .filter(row => this.toNumber(row.rb_battles) > 0);
@@ -189,7 +218,7 @@ export class GroundRbPanel {
                 <h3>Data, Source, And License</h3>
                 <p>Fork source: <a href="${this.sourceInfo.forkRepo}">zeoce/wt-data-project.web</a>. Upstream web: <a href="${this.sourceInfo.upstreamWebRepo}">ControlNet/wt-data-project.web</a>. Upstream data: <a href="${this.sourceInfo.upstreamDataRepo}">ControlNet/wt-data-project.data</a>.</p>
                 <p>This AGPL project keeps source availability and upstream attribution visible. Thunderskill-derived data is sample-based, and joined vehicle matching may contain errors. Treat low-sample rows as directional, not definitive.</p>
-                <p>Vehicle cards use local placeholder art because the current joined and wk data snapshots do not include safe image URLs, thumbnails, ranks, or finer vehicle-type fields. Ground frags and deaths on cards are estimates derived from battles and per-battle/per-death rates.</p>
+                <p>${this.imageSourceCopy()} Ground frags and deaths on cards are estimates derived from battles and per-battle/per-death rates.</p>
                 <p>Prepared: ${this.formatDate(this.sourceInfo.generatedAt)}. Latest data date: ${latest ? this.escape(latest.date) : "N/A"}.</p>
             </aside>
         `;
@@ -329,10 +358,7 @@ export class GroundRbPanel {
         const lowSample = this.toNumber(row.rb_battles) < minBattles * 2;
         return `
             <article class="vehicle-card${lowSample ? " low-sample-card" : ""}" data-nation="${this.escape(row.nation)}">
-                <div class="vehicle-art" aria-hidden="true">
-                    <div class="vehicle-art-mark">${this.escape(row.nation.slice(0, 3).toUpperCase())}</div>
-                    <div class="vehicle-art-name">${this.formatValue(row.rb_br)}</div>
-                </div>
+                ${this.vehicleArt(row)}
                 <div class="vehicle-card-body">
                     <h3>${this.displayName(row)}</h3>
                     <div class="badge-row">
@@ -567,6 +593,16 @@ export class GroundRbPanel {
         return response;
     }
 
+    private async loadImageManifest(): Promise<VehicleImageManifest | null> {
+        try {
+            const response = await fetch("data/vehicle-images.json");
+            if (!response.ok) return null;
+            return await response.json();
+        } catch {
+            return null;
+        }
+    }
+
     private readList(key: string): string[] {
         try {
             const value = JSON.parse(localStorage.getItem(key) || "[]");
@@ -599,6 +635,46 @@ export class GroundRbPanel {
 
     private stat(label: string, value: string): string {
         return `<div><dt>${label}</dt><dd>${this.formatValue(value)}</dd></div>`;
+    }
+
+    private vehicleArt(row: JoinedRow): string {
+        const image = this.vehicleImage(row);
+        const placeholder = `
+            <div class="vehicle-art-placeholder" aria-hidden="true">
+                <div class="vehicle-art-mark">${this.escape(row.nation.slice(0, 3).toUpperCase())}</div>
+                <div class="vehicle-art-name">${this.formatValue(row.rb_br)}</div>
+            </div>
+        `;
+        if (!image) {
+            return `<div class="vehicle-art">${placeholder}</div>`;
+        }
+        return `
+            <div class="vehicle-art has-image">
+                <img src="${this.escape(image.imageUrl)}" alt="${this.displayName(row)} vehicle image" loading="lazy" onerror="this.closest('.vehicle-art').classList.add('image-failed'); this.remove();">
+                <div class="vehicle-art-overlay" aria-hidden="true"></div>
+                <div class="vehicle-art-badges" aria-hidden="true">
+                    <span>${this.escape(row.nation)}</span>
+                    <span>BR ${this.formatValue(row.rb_br)}</span>
+                    ${this.isPremium(row) ? "<span class=\"premium-badge\">Premium</span>" : ""}
+                </div>
+                ${placeholder}
+            </div>
+        `;
+    }
+
+    private vehicleImage(row: JoinedRow): VehicleImage | null {
+        if (!this.imageManifest || !this.imageManifest.images) return null;
+        const image = this.imageManifest.images[row.name] || this.imageManifest.images[row.wk_name];
+        if (!image || image.confidence !== "high") return null;
+        return image;
+    }
+
+    private imageSourceCopy(): string {
+        if (!this.imageManifest) {
+            return "Vehicle image manifest is optional and was not loaded, so cards fall back to local placeholder panels.";
+        }
+        const source = this.imageManifest.source;
+        return `Vehicle card images are best-effort remote thumbnails from <a href="${this.escape(source.groundPage)}">${this.escape(source.name)}</a> / <a href="${this.escape(source.cdn)}">official wiki CDN</a>; ${this.escape(String(this.imageManifest.stats.matched))} matched and ${this.escape(String(this.imageManifest.stats.fallbacks))} use placeholders. Matching is based on joined vehicle ids and can miss renamed or unavailable vehicles. Images are referenced remotely rather than copied into this AGPL repository.`;
     }
 
     private typeLabel(row: JoinedRow): string {


### PR DESCRIPTION
## User-facing changes
- Adds real vehicle thumbnail support to the Ground RB card gallery using a static `data/vehicle-images.json` manifest.
- Cards lazy-load high-confidence images, keep the existing placeholder art when an image is unavailable, and automatically fall back if an image fails to load.
- Adds a 16:9 image area with dark overlays and top badges for nation, BR, and premium status.
- Updates the About/Data section and README with image source, best-effort matching, and fallback behavior.

## Image source chosen
- Source: official War Thunder Wiki Ground Vehicles page and official wiki CDN slot thumbnails from `static.encyclopedia.warthunder.com`.
- The build stores remote thumbnail URLs and source metadata in `public/data/vehicle-images.json`.
- Images are not copied or mirrored into this repository.

## Match results
- Matched vehicle images: 1,191
- Placeholder fallbacks in the current prepared Ground RB CSV: 0
- Validation examples with images: XM803, XM800T, T-55A, AMX-30 Super, BMP-3.
- Leopard 1A5BE is not present in the current joined Ground RB CSV snapshot, so no card/image can be validated for that row in this data version.

## Licensing/source caveats
- Matching is best-effort and based on joined vehicle ids against official wiki unit ids.
- Remote image usage depends on War Thunder Wiki/Gaijin terms and CDN availability; the app keeps source attribution visible and falls back safely if images are missing or fail.
- `WT_DISABLE_IMAGE_FETCH=1 npm run prepare:images` can generate a placeholder-only manifest if the wiki endpoint is unavailable.

## Testing performed
- `npm ci`
- `npm run prepare:data`
- `npm run prepare:images`
- `npm run build:pages`
- `npm run check:dist`
- Local smoke test confirmed cards render with lazy-loaded wiki CDN images.
- Local smoke test confirmed cards still render with placeholders when `data/vehicle-images.json` is missing.