### PR TITLE
Polish vehicle cards and add image preview modal

### DIFF
--- a/index.css
+++ b/index.css
@@ -965,12 +965,20 @@ body:not(.dark-mode) .results-toolbar{
 
 .ground-card-view{
   display:grid;
-  grid-template-columns:repeat(auto-fit, minmax(230px, 1fr));
-  gap:14px;
-  margin:14px 0;
+  grid-template-columns:minmax(0, min(100%, 320px));
+  justify-content:center;
+  align-items:stretch;
+  gap:18px;
+  max-width:1346px;
+  margin:18px auto;
 }
 
 .vehicle-card{
+  display:flex;
+  flex-direction:column;
+  min-width:0;
+  width:100%;
+  height:100%;
   overflow:hidden;
   border:1px solid rgba(137,221,255,.16);
   border-radius:16px;
@@ -979,6 +987,10 @@ body:not(.dark-mode) .results-toolbar{
     var(--panel);
   color:#eaf6ff;
   box-shadow:0 14px 34px rgba(0,0,0,.28);
+}
+
+.vehicle-card.premium-card{
+  border-color:rgba(255,203,107,.24);
 }
 
 body:not(.dark-mode) .vehicle-card{
@@ -992,10 +1004,11 @@ body:not(.dark-mode) .vehicle-card{
 .vehicle-art{
   aspect-ratio:16 / 9;
   position:relative;
+  flex:0 0 auto;
   display:flex;
   align-items:flex-end;
   justify-content:space-between;
-  padding:12px;
+  min-height:158px;
   background:
     radial-gradient(circle at 28% 40%, rgba(125,159,180,.22), transparent 9rem),
     linear-gradient(135deg, rgba(50,65,76,.86), rgba(15,22,29,.92) 58%, rgba(28,38,26,.8));
@@ -1013,12 +1026,41 @@ body:not(.dark-mode) .vehicle-card{
   transform:skewX(-12deg);
 }
 
+.vehicle-image-button{
+  position:absolute;
+  inset:0;
+  z-index:0;
+  display:block;
+  width:100%;
+  height:100%;
+  min-height:0;
+  padding:0;
+  border:0;
+  border-radius:0;
+  background:transparent;
+  box-shadow:none;
+  cursor:zoom-in;
+}
+
+.vehicle-image-button:hover,
+.vehicle-image-button:focus-visible{
+  transform:none;
+  border-color:transparent;
+  background:transparent;
+  box-shadow:none;
+}
+
+.vehicle-image-button:focus-visible{
+  outline:3px solid rgba(137,221,255,.7);
+  outline-offset:-4px;
+}
+
 .vehicle-art img{
   position:absolute;
   inset:0;
   width:100%;
   height:100%;
-  object-position:center;
+  object-position:center center;
   z-index:0;
 }
 
@@ -1028,12 +1070,13 @@ body:not(.dark-mode) .vehicle-card{
 
 .vehicle-art img.fit-contain{
   object-fit:contain;
-  padding:10px;
+  padding:8px;
+  background:radial-gradient(circle at 50% 45%, rgba(137,221,255,.12), rgba(4,8,12,.72) 68%);
 }
 
 .vehicle-art.using-fallback-image img{
   object-fit:contain;
-  padding:10px;
+  padding:8px;
 }
 
 .vehicle-art.has-image:before{
@@ -1048,6 +1091,7 @@ body:not(.dark-mode) .vehicle-card{
   align-items:flex-end;
   justify-content:space-between;
   padding:12px;
+  pointer-events:none;
 }
 
 .vehicle-art.has-image .vehicle-art-placeholder{
@@ -1064,8 +1108,8 @@ body:not(.dark-mode) .vehicle-card{
   inset:0;
   z-index:1;
   background:
-    linear-gradient(180deg, rgba(8,12,16,.08), rgba(8,12,16,.58) 72%, rgba(8,12,16,.86)),
-    linear-gradient(90deg, rgba(8,12,16,.36), rgba(8,12,16,.05) 48%, rgba(8,12,16,.42));
+    linear-gradient(180deg, rgba(8,12,16,0) 36%, rgba(8,12,16,.58) 78%, rgba(8,12,16,.88)),
+    linear-gradient(90deg, rgba(8,12,16,.22), rgba(8,12,16,0) 48%, rgba(8,12,16,.26));
   pointer-events:none;
 }
 
@@ -1078,6 +1122,7 @@ body:not(.dark-mode) .vehicle-card{
   display:flex;
   flex-wrap:wrap;
   gap:6px;
+  pointer-events:none;
 }
 
 .vehicle-art-badges span{
@@ -1118,21 +1163,31 @@ body:not(.dark-mode) .vehicle-card{
 }
 
 .vehicle-card-body{
+  display:flex;
+  flex:1 1 auto;
+  flex-direction:column;
   padding:14px;
 }
 
 .vehicle-card h3{
-  margin:0 0 10px;
+  height:2.52rem;
+  margin:0 0 8px;
   color:#ffffff;
+  display:-webkit-box;
   font-size:1.05rem;
   line-height:1.2;
+  overflow:hidden;
+  -webkit-box-orient:vertical;
+  -webkit-line-clamp:2;
 }
 
 .badge-row{
   display:flex;
   flex-wrap:wrap;
   gap:6px;
-  margin-bottom:12px;
+  min-height:54px;
+  margin-bottom:8px;
+  align-content:flex-start;
 }
 
 .badge-row span{
@@ -1149,6 +1204,24 @@ body:not(.dark-mode) .vehicle-card{
   border-color:rgba(255,203,107,.3);
   background:rgba(255,203,107,.14);
   color:#ffd86b;
+}
+
+.status-row{
+  min-height:28px;
+  margin-bottom:10px;
+}
+
+.status-row .premium-badge{
+  display:inline-flex;
+  align-items:center;
+  min-height:24px;
+  border:1px solid rgba(255,203,107,.32);
+  border-radius:999px;
+  background:rgba(255,203,107,.14);
+  color:#ffd86b;
+  padding:3px 8px;
+  font-size:.78rem;
+  font-weight:850;
 }
 
 .stat-grid{
@@ -1182,16 +1255,22 @@ body:not(.dark-mode) .vehicle-card{
 }
 
 .card-caveat{
-  margin:10px 0 0;
+  margin:0;
   color:#ffd86b;
   font-size:.86rem;
+}
+
+.card-caveat-row{
+  min-height:30px;
+  margin-top:10px;
 }
 
 .card-actions{
   display:grid;
   grid-template-columns:1fr 1fr;
   gap:8px;
-  margin-top:12px;
+  margin-top:auto;
+  padding-top:12px;
 }
 
 .card-actions button{
@@ -1216,15 +1295,113 @@ body:not(.dark-mode) .vehicle-card{
   color:#eaf6ff;
 }
 
-@media (min-width:1300px){
+body.modal-open{
+  overflow:hidden;
+}
+
+.vehicle-image-modal[hidden]{
+  display:none;
+}
+
+.vehicle-image-modal{
+  position:fixed;
+  inset:0;
+  z-index:50;
+  display:grid;
+  place-items:center;
+  padding:24px;
+}
+
+.vehicle-image-backdrop{
+  position:absolute;
+  inset:0;
+  background:rgba(2,6,10,.78);
+  backdrop-filter:blur(4px);
+}
+
+.vehicle-image-dialog{
+  position:relative;
+  z-index:1;
+  width:min(1040px, 100%);
+  max-height:min(86vh, 860px);
+  display:flex;
+  flex-direction:column;
+  overflow:hidden;
+  border:1px solid rgba(137,221,255,.26);
+  border-radius:18px;
+  background:linear-gradient(180deg, rgba(20,30,40,.98), rgba(7,11,16,.98));
+  color:#eaf6ff;
+  box-shadow:0 30px 90px rgba(0,0,0,.58);
+}
+
+.vehicle-image-dialog-head{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:16px;
+  padding:14px 16px;
+  border-bottom:1px solid rgba(137,221,255,.16);
+}
+
+.vehicle-image-dialog h3{
+  margin:0 0 4px;
+  font-size:1.15rem;
+  color:#ffffff;
+}
+
+.vehicle-image-dialog a{
+  color:#9bdcff;
+  font-size:.9rem;
+}
+
+#vehicle-image-close{
+  flex:0 0 auto;
+  min-height:38px;
+  border-color:rgba(137,221,255,.24);
+  background:rgba(137,221,255,.1);
+  color:#eaf6ff;
+}
+
+.vehicle-image-preview-frame{
+  min-height:0;
+  padding:14px;
+  background:
+    radial-gradient(circle at 50% 35%, rgba(137,221,255,.1), transparent 42%),
+    #05090d;
+}
+
+.vehicle-image-preview-frame img{
+  display:block;
+  width:100%;
+  max-height:calc(86vh - 116px);
+  object-fit:contain;
+  border-radius:10px;
+}
+
+.vehicle-image-dialog.image-failed .vehicle-image-preview-frame:after{
+  content:"Image preview could not load.";
+  display:grid;
+  min-height:280px;
+  place-items:center;
+  color:#b8c7d4;
+  font-weight:800;
+}
+
+@media (min-width:1380px){
   .ground-card-view{
-    grid-template-columns:repeat(5, minmax(0, 1fr));
+    grid-template-columns:repeat(4, minmax(280px, 320px));
   }
 }
 
-@media (max-width:1050px){
+@media (min-width:1180px) and (max-width:1379px){
   .ground-card-view{
-    grid-template-columns:repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns:repeat(3, minmax(280px, 320px));
+  }
+}
+
+@media (min-width:660px) and (max-width:1179px){
+  .ground-card-view{
+    grid-template-columns:repeat(2, minmax(280px, 320px));
   }
 }
 
@@ -1245,6 +1422,19 @@ body:not(.dark-mode) .vehicle-card{
 
   .ground-card-view{
     grid-template-columns:1fr;
+  }
+
+  .vehicle-image-modal{
+    padding:12px;
+  }
+
+  .vehicle-image-dialog-head{
+    align-items:stretch;
+    flex-direction:column;
+  }
+
+  #vehicle-image-close{
+    width:100%;
   }
 
   .stat-grid{

--- a/src/app/ground-rb-panel.ts
+++ b/src/app/ground-rb-panel.ts
@@ -33,6 +33,8 @@ type SourceInfo = {
 
 type VehicleImage = {
     imageUrl: string;
+    thumbnailUrl?: string;
+    previewUrl?: string;
     fallbackImageUrl: string;
     sourcePage: string;
     sourceFileTitle: string;
@@ -230,6 +232,21 @@ export class GroundRbPanel {
                 <p>${this.imageSourceCopy()} Ground frags and deaths on cards are estimates derived from battles and per-battle/per-death rates.</p>
                 <p>Prepared: ${this.formatDate(this.sourceInfo.generatedAt)}. Latest data date: ${latest ? this.escape(latest.date) : "N/A"}.</p>
             </aside>
+            <div id="vehicle-image-modal" class="vehicle-image-modal" hidden>
+                <div class="vehicle-image-backdrop" data-modal-close></div>
+                <section class="vehicle-image-dialog" role="dialog" aria-modal="true" aria-labelledby="vehicle-image-title">
+                    <div class="vehicle-image-dialog-head">
+                        <div>
+                            <h3 id="vehicle-image-title"></h3>
+                            <a id="vehicle-image-source" href="#" target="_blank" rel="noreferrer"></a>
+                        </div>
+                        <button type="button" id="vehicle-image-close" aria-label="Close image preview">Close</button>
+                    </div>
+                    <div class="vehicle-image-preview-frame">
+                        <img id="vehicle-image-preview" alt="" onerror="this.closest('.vehicle-image-dialog').classList.add('image-failed'); this.removeAttribute('src');">
+                    </div>
+                </section>
+            </div>
         `;
         this.bindEvents();
         this.renderMemory();
@@ -249,6 +266,11 @@ export class GroundRbPanel {
         this.byId("show-more-cards").addEventListener("click", () => {
             this.visibleCards += CARD_PAGE_SIZE;
             this.updateResults();
+        });
+        this.byId("vehicle-image-close").addEventListener("click", () => this.closeImagePreview());
+        this.root.querySelector("[data-modal-close]").addEventListener("click", () => this.closeImagePreview());
+        document.addEventListener("keydown", event => {
+            if (event.key === "Escape") this.closeImagePreview();
         });
 
         this.byId("preset-win").addEventListener("click", () => this.applyPreset("win"));
@@ -291,6 +313,9 @@ export class GroundRbPanel {
         });
         Array.prototype.forEach.call(container.querySelectorAll("[data-show-plot]"), (button: HTMLButtonElement) => {
             button.addEventListener("click", () => this.showLegacyPlot(button.getAttribute("data-show-plot")));
+        });
+        Array.prototype.forEach.call(container.querySelectorAll("[data-image-preview]"), (button: HTMLButtonElement) => {
+            button.addEventListener("click", () => this.openImagePreview(button.getAttribute("data-image-preview")));
         });
     }
 
@@ -367,7 +392,7 @@ export class GroundRbPanel {
         const favorite = this.favorites.indexOf(row.name) >= 0;
         const lowSample = this.toNumber(row.rb_battles) < minBattles * 2;
         return `
-            <article class="vehicle-card${lowSample ? " low-sample-card" : ""}" data-nation="${this.escape(row.nation)}">
+            <article class="vehicle-card${this.isPremium(row) ? " premium-card" : ""}${lowSample ? " low-sample-card" : ""}" data-nation="${this.escape(row.nation)}">
                 ${this.vehicleArt(row)}
                 <div class="vehicle-card-body">
                     <h3>${this.displayName(row)}</h3>
@@ -377,8 +402,8 @@ export class GroundRbPanel {
                         <span>${this.escape(row.nation)}</span>
                         <span>${this.escape(this.typeLabel(row))}</span>
                         <span>Rank N/A</span>
-                        ${this.isPremium(row) ? "<span class=\"premium-badge\">Premium</span>" : ""}
                     </div>
+                    <div class="status-row">${this.isPremium(row) ? "<span class=\"premium-badge\">Premium</span>" : ""}</div>
                     <dl class="stat-grid">
                         ${this.stat("Battles", row.rb_battles)}
                         ${this.stat("Win rate", `${this.formatValue(row.rb_win_rate)}%`)}
@@ -389,7 +414,7 @@ export class GroundRbPanel {
                         ${this.stat("SL / game", row.rb_sl_rate)}
                         ${this.stat("RP / game", row.rb_rp_rate)}
                     </dl>
-                    ${lowSample ? "<p class=\"card-caveat\">Low sample: treat cautiously.</p>" : ""}
+                    <div class="card-caveat-row">${lowSample ? "<p class=\"card-caveat\">Low sample: treat cautiously.</p>" : ""}</div>
                     <div class="card-actions">
                         <button type="button" data-select="${this.escape(row.name)}">Details</button>
                         <button type="button" data-compare="${this.escape(row.name)}">${compared ? "Remove" : "Compare"}</button>
@@ -411,6 +436,40 @@ export class GroundRbPanel {
         history.replaceState(null, document.title, `${window.location.pathname}?${params.toString()}${window.location.hash}`);
         this.renderDetail(row);
         this.renderMemory();
+    }
+
+    private openImagePreview(name: string): void {
+        const row = this.rows.filter(item => item.name === name)[0];
+        if (!row) return;
+        const image = this.vehicleImage(row);
+        if (!image) return;
+        const modal = this.byId("vehicle-image-modal") as HTMLElement;
+        const title = this.byId("vehicle-image-title");
+        const link = this.byId("vehicle-image-source") as HTMLAnchorElement;
+        const preview = this.byId("vehicle-image-preview") as HTMLImageElement;
+        const sourceUrl = image.sourceUrl || image.sourcePage || "";
+        title.textContent = (row.alt_name || row.wk_name || row.name).replace(/_/g, " ");
+        preview.closest(".vehicle-image-dialog")?.classList.remove("image-failed");
+        preview.src = image.previewUrl || image.imageUrl;
+        preview.alt = `${title.textContent} vehicle image`;
+        if (sourceUrl) {
+            link.href = sourceUrl;
+            link.textContent = image.sourceFileTitle || "Image source";
+            link.hidden = false;
+        } else {
+            link.hidden = true;
+        }
+        modal.hidden = false;
+        document.body.classList.add("modal-open");
+        (this.byId("vehicle-image-close") as HTMLButtonElement).focus();
+    }
+
+    private closeImagePreview(): void {
+        const modal = this.byId("vehicle-image-modal") as HTMLElement;
+        if (!modal || modal.hidden) return;
+        modal.hidden = true;
+        document.body.classList.remove("modal-open");
+        (this.byId("vehicle-image-preview") as HTMLImageElement).removeAttribute("src");
     }
 
     private renderDetail(row: JoinedRow): void {
@@ -662,7 +721,9 @@ export class GroundRbPanel {
         const fitClass = this.imageFitClass(image);
         return `
             <div class="vehicle-art has-image" data-image-source="${this.escape(image.sourceKind)}" data-image-score="${this.escape(String(image.score || 0))}">
-                <img class="${fitClass}" src="${this.escape(image.imageUrl)}" data-fallback-src="${this.escape(fallback || "")}" alt="${this.displayName(row)} vehicle image" loading="lazy" onerror="if (this.dataset.fallbackSrc) { this.src = this.dataset.fallbackSrc; this.dataset.fallbackSrc = ''; this.classList.add('fit-contain'); this.closest('.vehicle-art').classList.add('using-fallback-image'); } else { this.closest('.vehicle-art').classList.add('image-failed'); this.remove(); }">
+                <button type="button" class="vehicle-image-button" data-image-preview="${this.escape(row.name)}" aria-label="Open ${this.displayName(row)} image preview">
+                    <img class="${fitClass}" src="${this.escape(image.thumbnailUrl || image.imageUrl)}" data-fallback-src="${this.escape(fallback || "")}" alt="${this.displayName(row)} vehicle image" loading="lazy" onerror="if (this.dataset.fallbackSrc) { this.src = this.dataset.fallbackSrc; this.dataset.fallbackSrc = ''; this.classList.add('fit-contain'); this.closest('.vehicle-art').classList.add('using-fallback-image'); } else { this.closest('.vehicle-art').classList.add('image-failed'); this.remove(); }">
+                </button>
                 <div class="vehicle-art-overlay" aria-hidden="true"></div>
                 <div class="vehicle-art-badges" aria-hidden="true">
                     <span>${this.escape(row.nation)}</span>


### PR DESCRIPTION
## User-facing changes
- Enlarges and centers the Ground RB card grid with 4/3/2/1 responsive column breakpoints and wider 280-320px card tracks where space allows.
- Makes vehicle cards full-height flex columns so image headers, titles, chips, stats, warnings, and action buttons align consistently across rows.
- Improves vehicle image framing with a fixed 16:9 header area, centered object positioning, less aggressive gradient overlay, and non-stretching contain fallback styling.
- Adds a keyboard-accessible vehicle image preview modal/lightbox with source link, close button, Escape close, and backdrop close.
- Keeps Details, Compare, Favourite, and Show plot actions separate from image preview clicks.

## Image/source notes
- The modal uses the existing static vehicle image manifest URLs; there are no browser runtime API calls.
- `previewUrl` and `thumbnailUrl` are supported if the manifest adds them later, with current manifests falling back to `imageUrl`.

## Testing performed
- `npm ci`
- `npm run prepare:data`
- `npm run prepare:images`
- `npm run build:pages`
- `npm run check:dist`
- Manual browser validation on built `dist`: responsive 4/3/2/1 grid breakpoints, card widths/heights/action alignment, image preview open, Escape close, backdrop close, Details, Compare, Favourite, Show plot, and named vehicle checks.

## Notes
- `npm ci` reports existing audit findings: 1 moderate and 9 high vulnerabilities.
- `npm run build:pages` reports existing webpack asset-size warnings.
- VBCI appears when the current filters allow it; with the default 1000 minimum battles filter it is hidden, and with min battles lowered it renders with image previews.