### PR TITLE
Improve Ground RB layout, defaults, cards, and saved controls

### DIFF
--- a/index.css
+++ b/index.css
@@ -64,6 +64,26 @@ div#sidebar label{
   top:0;
   background:var(--bg);
   z-index:3;
+  overflow:hidden;
+  transition:flex-basis .18s ease, max-width .18s ease, padding .18s ease, opacity .18s ease, border-width .18s ease;
+}
+
+.sidebar-toggle-btn{
+  position:sticky;
+  top:58px;
+  align-self:flex-start;
+  z-index:4;
+  margin:10px 0 0 8px;
+  white-space:nowrap;
+}
+
+#sidebar.collapsed{
+  flex-basis:0;
+  max-width:0;
+  padding:0;
+  opacity:0;
+  border-width:0;
+  pointer-events:none;
 }
 
 #sidebar label{
@@ -341,6 +361,16 @@ svg{
     display:grid;
     grid-template-columns:repeat(2,minmax(0,1fr));
     gap:8px;
+  }
+
+  .sidebar-toggle-btn{
+    position:static;
+    width:calc(100% - 16px);
+    margin:8px;
+  }
+
+  #sidebar.collapsed{
+    display:none;
   }
 
   #content{
@@ -704,9 +734,60 @@ input:focus-visible{
   background:color-mix(in srgb, var(--warn) 80%, transparent);
 }
 
+.table-legend{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  margin:8px 10px 10px;
+  color:var(--muted);
+  font-size:.88rem;
+}
+
+.table-legend-swatch{
+  width:18px;
+  height:12px;
+  border:1px solid var(--border);
+  border-radius:3px;
+  background:color-mix(in srgb, var(--warn) 80%, transparent);
+}
+
 .ground-rb-results td:first-child button{
   font-weight:800;
   color:var(--accent-strong);
+}
+
+.memory-chip{
+  display:inline-flex;
+  align-items:stretch;
+}
+
+.memory-chip .chip-main{
+  border-radius:10px 0 0 10px;
+}
+
+.memory-chip .chip-remove{
+  min-width:34px;
+  padding:8px;
+  border-left:0;
+  border-radius:0 10px 10px 0;
+  color:var(--muted);
+}
+
+.clear-memory,
+#clear-comparison{
+  color:var(--muted);
+}
+
+.compare-actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin:0 0 10px;
+}
+
+.compare-remove{
+  min-height:34px;
+  padding:6px 8px;
 }
 
 /* Vehicle detail + comparison */
@@ -1430,7 +1511,13 @@ body.modal-open{
   }
 }
 
-@media (min-width:660px) and (max-width:1179px){
+@media (min-width:980px) and (max-width:1179px){
+  .ground-card-view{
+    grid-template-columns:repeat(3, minmax(280px, 320px));
+  }
+}
+
+@media (min-width:660px) and (max-width:979px){
   .ground-card-view{
     grid-template-columns:repeat(2, minmax(280px, 320px));
   }

--- a/src/app/application.ts
+++ b/src/app/application.ts
@@ -59,6 +59,8 @@ export class Application {
                     .map(each => each.date)
                     .reverse();
 
+                Application.initSidebarToggle();
+
                 // initialize the logo
                 Application.logo = Container.get(Application.Logo);
                 Application.logo.init();
@@ -80,6 +82,34 @@ export class Application {
                     true
                 );
             });
+    }
+
+    static initSidebarToggle(): void {
+        const sidebar = document.getElementById("sidebar");
+        if (!sidebar || document.getElementById("sidebar-toggle")) return;
+        const main = document.getElementById("main-div");
+        const button = document.createElement("button");
+        button.type = "button";
+        button.id = "sidebar-toggle";
+        button.className = "sidebar-toggle-btn";
+        button.setAttribute("aria-controls", "sidebar");
+
+        let collapsed = localStorage.getItem("wt-sidebar-collapsed");
+        let isCollapsed = collapsed === null ? true : collapsed === "true";
+        const apply = () => {
+            sidebar.classList.toggle("collapsed", isCollapsed);
+            main?.classList.toggle("sidebar-collapsed", isCollapsed);
+            button.setAttribute("aria-expanded", String(!isCollapsed));
+            button.textContent = isCollapsed ? "Filters" : "Hide filters";
+        };
+
+        button.addEventListener("click", () => {
+            isCollapsed = !isCollapsed;
+            localStorage.setItem("wt-sidebar-collapsed", String(isCollapsed));
+            apply();
+        });
+        sidebar.parentElement?.insertBefore(button, sidebar);
+        apply();
     }
 
     static renderDataStatus(message: string, error = false): void {

--- a/src/app/ground-rb-panel.ts
+++ b/src/app/ground-rb-panel.ts
@@ -207,10 +207,10 @@ export class GroundRbPanel {
             <div class="results-toolbar" aria-label="Vehicle result display controls">
                 <label>Sort
                     ${this.selectBare("ground-sort", [
-                        ["gkd", "Ground kills per death descending"],
+                        ["gkd", "Frags / death descending"],
                         ["win", "Win rate descending"],
                         ["played", "Battles descending"],
-                        ["gkb", "Ground kills per battle descending"],
+                        ["gkb", "Frags / battle descending"],
                         ["brAsc", "BR ascending"],
                         ["brDesc", "BR descending"],
                         ["name", "Name A-Z"]
@@ -234,14 +234,15 @@ export class GroundRbPanel {
                             ${this.tableHeader("rank", "Rank")}
                             ${this.tableHeader("win", "Win")}
                             ${this.tableHeader("battles", "Battles")}
-                            ${this.tableHeader("gkb", "G/K")}
-                            ${this.tableHeader("gkd", "G/D")}
+                            ${this.tableHeader("gkb", "Frags / battle")}
+                            ${this.tableHeader("gkd", "Frags / death")}
                             ${this.tableHeader("premium", "Premium")}
                             <th aria-label="Actions"></th>
                         </tr>
                     </thead>
                     <tbody id="ground-results"></tbody>
                 </table>
+                <p class="table-legend"><span class="table-legend-swatch" aria-hidden="true"></span>Gold rows indicate low sample size; interpret cautiously.</p>
             </div>
             <div class="ground-panels">
                 <article id="vehicle-detail" class="vehicle-detail" aria-live="polite"></article>
@@ -449,10 +450,10 @@ export class GroundRbPanel {
 
     private resultRow(row: JoinedRow, minBattles: number, rank: number): string {
         const battles = this.toNumber(row.rb_battles);
-        const low = battles < minBattles * 2 ? " low-sample" : "";
+        const low = battles < minBattles * 2;
         const compared = this.compareNames.indexOf(row.name) >= 0;
         return `
-            <tr class="${low}">
+            <tr${low ? " class=\"low-sample\" title=\"Low sample size; interpret cautiously\"" : ""}>
                 <td><button type="button" data-select="${this.escape(row.name)}">${this.displayName(row)}</button></td>
                 <td>${this.escape(row.nation)}</td>
                 <td>${this.formatValue(row.rb_br)}</td>
@@ -566,8 +567,8 @@ export class GroundRbPanel {
                 <dt>AB / RB / SB BR</dt><dd>${this.formatValue(row.ab_br)} / ${this.formatValue(row.rb_br)} / ${this.formatValue(row.sb_br)}</dd>
                 <dt>RB win rate</dt><dd>${this.formatPercentage(row.rb_win_rate)}</dd>
                 <dt>RB battles</dt><dd>${this.formatCount(row.rb_battles)}</dd>
-                <dt>RB ground frags/battle</dt><dd>${this.formatRatio(row.rb_ground_frags_per_battle)}</dd>
-                <dt>RB ground frags/death</dt><dd>${this.formatRatio(row.rb_ground_frags_per_death)}</dd>
+                <dt>RB frags / battle</dt><dd>${this.formatRatio(row.rb_ground_frags_per_battle)}</dd>
+                <dt>RB frags / death</dt><dd>${this.formatRatio(row.rb_ground_frags_per_death)}</dd>
                 <dt>RB repair</dt><dd>${this.formatCount(row.rb_repair)}</dd>
                 <dt>Premium</dt><dd>${this.isPremium(row) ? "Yes" : "No"}</dd>
                 <dt>Source update</dt><dd>${this.sourceInfo ? this.escape(this.sourceInfo.latestJoined.date) : "N/A"}</dd>
@@ -593,17 +594,24 @@ export class GroundRbPanel {
         }
         container.innerHTML = `
             <h3>Comparison</h3>
+            <div class="compare-actions">
+                <button type="button" id="copy-comparison">Copy comparison summary</button>
+                <button type="button" id="clear-comparison">Clear comparison</button>
+            </div>
             <div class="ground-rb-results-wrap">
                 <table class="compare-table">
-                    <thead><tr><th>Vehicle</th><th>BR</th><th>Win</th><th>Battles</th><th>G/K</th><th>G/D</th><th>Repair</th><th>Premium</th></tr></thead>
+                    <thead><tr><th>Vehicle</th><th>BR</th><th>Win</th><th>Battles</th><th>Frags / battle</th><th>Frags / death</th><th>Repair</th><th>Premium</th><th aria-label="Actions"></th></tr></thead>
                     <tbody>${rows.map(row => `
-                        <tr><td>${this.displayName(row)}</td><td>${this.formatValue(row.rb_br)}</td><td>${this.formatPercentage(row.rb_win_rate)}</td><td>${this.formatCount(row.rb_battles)}</td><td>${this.formatRatio(row.rb_ground_frags_per_battle)}</td><td>${this.formatRatio(row.rb_ground_frags_per_death)}</td><td>${this.formatCount(row.rb_repair)}</td><td>${this.isPremium(row) ? "Yes" : "No"}</td></tr>
+                        <tr><td>${this.displayName(row)}</td><td>${this.formatValue(row.rb_br)}</td><td>${this.formatPercentage(row.rb_win_rate)}</td><td>${this.formatCount(row.rb_battles)}</td><td>${this.formatRatio(row.rb_ground_frags_per_battle)}</td><td>${this.formatRatio(row.rb_ground_frags_per_death)}</td><td>${this.formatCount(row.rb_repair)}</td><td>${this.isPremium(row) ? "Yes" : "No"}</td><td><button type="button" class="compare-remove" data-remove-compare="${this.escape(row.name)}">Remove</button></td></tr>
                     `).join("")}</tbody>
                 </table>
             </div>
-            <button type="button" id="copy-comparison">Copy comparison summary</button>
         `;
         this.byId("copy-comparison").addEventListener("click", () => this.copyComparison());
+        this.byId("clear-comparison").addEventListener("click", () => this.clearCompare());
+        Array.prototype.forEach.call(container.querySelectorAll("[data-remove-compare]"), (button: HTMLButtonElement) => {
+            button.addEventListener("click", () => this.removeCompare(button.getAttribute("data-remove-compare")));
+        });
     }
 
     private copyComparison(): void {
@@ -611,7 +619,7 @@ export class GroundRbPanel {
             .map(name => this.rows.filter(row => row.name === name)[0])
             .filter(row => row);
         const text = rows.map(row =>
-            `${this.displayName(row)}: BR ${this.formatValue(row.rb_br)}, ${this.formatPercentage(row.rb_win_rate)} WR, ${this.formatCount(row.rb_battles)} battles, ${this.formatRatio(row.rb_ground_frags_per_battle)} G/K, ${this.formatRatio(row.rb_ground_frags_per_death)} G/D`
+            `${this.displayName(row)}: BR ${this.formatValue(row.rb_br)}, ${this.formatPercentage(row.rb_win_rate)} WR, ${this.formatCount(row.rb_battles)} battles, ${this.formatRatio(row.rb_ground_frags_per_battle)} frags / battle, ${this.formatRatio(row.rb_ground_frags_per_death)} frags / death`
         ).join("\n");
         navigator.clipboard?.writeText(text);
     }
@@ -658,7 +666,14 @@ export class GroundRbPanel {
     private renderMemory(): void {
         const recent = this.root.querySelector("#recent-searches");
         const favorites = this.root.querySelector("#favorite-vehicles");
-        if (recent) recent.innerHTML = this.recentSearches.slice(0, 5).map(text => `<button type="button" data-memory="${this.escape(text)}">${this.escape(text)}</button>`).join("");
+        if (recent) {
+            recent.innerHTML = this.recentSearches.slice(0, 5).map(text => `
+                <span class="memory-chip">
+                    <button type="button" class="chip-main" data-memory="${this.escape(text)}">${this.escape(text)}</button>
+                    <button type="button" class="chip-remove" data-remove-recent="${this.escape(text)}" aria-label="Remove ${this.escape(text)} from recent searches">x</button>
+                </span>
+            `).join("") + (this.recentSearches.length ? `<button type="button" class="clear-memory" id="clear-recent-searches">Clear</button>` : "");
+        }
         if (favorites) favorites.innerHTML = this.favorites.slice(0, 8).map(name => {
             const row = this.rows.filter(item => item.name === name)[0];
             return row ? `<button type="button" data-favorite="${this.escape(row.name)}">${this.displayName(row)}</button>` : "";
@@ -669,6 +684,22 @@ export class GroundRbPanel {
                 this.updateResults();
             });
         });
+        Array.prototype.forEach.call(this.root.querySelectorAll("[data-remove-recent]"), (button: HTMLButtonElement) => {
+            button.addEventListener("click", () => {
+                const value = button.getAttribute("data-remove-recent") || "";
+                this.recentSearches = this.recentSearches.filter(item => item !== value);
+                localStorage.setItem(STORAGE_RECENT, JSON.stringify(this.recentSearches));
+                this.renderMemory();
+            });
+        });
+        const clearRecent = this.root.querySelector("#clear-recent-searches");
+        if (clearRecent) {
+            clearRecent.addEventListener("click", () => {
+                this.recentSearches = [];
+                localStorage.setItem(STORAGE_RECENT, JSON.stringify(this.recentSearches));
+                this.renderMemory();
+            });
+        }
         Array.prototype.forEach.call(this.root.querySelectorAll("[data-favorite]"), (button: HTMLButtonElement) => {
             button.addEventListener("click", () => this.selectVehicle(button.getAttribute("data-favorite")));
         });
@@ -682,6 +713,21 @@ export class GroundRbPanel {
         } else if (this.compareNames.length < 4) {
             this.compareNames.push(name);
         }
+        localStorage.setItem(STORAGE_COMPARE, JSON.stringify(this.compareNames));
+        this.renderCompare();
+        this.updateResults();
+    }
+
+    private removeCompare(name: string): void {
+        if (!name) return;
+        this.compareNames = this.compareNames.filter(item => item !== name);
+        localStorage.setItem(STORAGE_COMPARE, JSON.stringify(this.compareNames));
+        this.renderCompare();
+        this.updateResults();
+    }
+
+    private clearCompare(): void {
+        this.compareNames = [];
         localStorage.setItem(STORAGE_COMPARE, JSON.stringify(this.compareNames));
         this.renderCompare();
         this.updateResults();
@@ -910,9 +956,19 @@ export class GroundRbPanel {
         const classSelect = document.getElementById("class-selection") as HTMLSelectElement;
         const modeSelect = document.getElementById("mode-selection") as HTMLSelectElement;
         const brRangeSelect = document.getElementById("br-range-selection") as HTMLSelectElement;
+        const viewSelect = document.getElementById("view-mode-selection") as HTMLSelectElement;
+        if (viewSelect) {
+            viewSelect.value = "heatmap";
+            localStorage.setItem("view-mode-selection", "heatmap");
+            viewSelect.dispatchEvent(new Event("change", { bubbles: true }));
+        }
         if (classSelect) classSelect.value = "Ground_vehicles";
         if (modeSelect) modeSelect.value = "rb";
-        if (brRangeSelect) brRangeSelect.value = "1";
+        if (brRangeSelect) {
+            brRangeSelect.value = "0";
+            localStorage.setItem("br-range-selection", "0");
+            brRangeSelect.dispatchEvent(new Event("change", { bubbles: true }));
+        }
         const target = document.getElementById("main-svg") || document.getElementById("content");
         target?.scrollIntoView({ behavior: "smooth", block: "start" });
         this.selectVehicle(row.name);

--- a/src/app/page/br-heatmap-page.ts
+++ b/src/app/page/br-heatmap-page.ts
@@ -1,8 +1,8 @@
 import { Page } from "./page";
 import { Container, Inject, Singleton, utils } from "../../utils";
 import { BrHeatmap } from "../../plot/br-heatmap";
-import { Sidebar } from "../global-env";
-import { BrRangeSelect, ClassSelect, DateSelect, MeasurementSelect, ModeSelect, Select } from "../sidebar/select";
+import { Content, Sidebar } from "../global-env";
+import { BrRangeSelect, ClassSelect, DateSelect, MeasurementSelect, ModeSelect, Select, ViewModeSelect } from "../sidebar/select";
 import * as d3 from "d3";
 import { BRRange, Clazz, Measurement, Mode } from "../options";
 import { Localization } from "../config";
@@ -21,7 +21,20 @@ export class BRHeatMapPage extends Page {
     update(): void {
         // remove old plot
         this.removeOld();
-        new GroundRbPanel(Application.metadata).render(document.getElementById("content"));
+        const content = document.getElementById("content");
+        if (!content) return;
+        content.innerHTML = "";
+        const resultsWrapper = document.createElement("div");
+        resultsWrapper.id = "ground-rb-wrapper";
+        const heatmapWrapper = document.createElement("div");
+        heatmapWrapper.id = "legacy-heatmap-wrapper";
+        heatmapWrapper.hidden = true;
+        content.appendChild(resultsWrapper);
+        content.appendChild(heatmapWrapper);
+        new GroundRbPanel(Application.metadata).render(resultsWrapper);
+
+        // add view selection
+        Container.get<Select>(ViewModeSelect).init();
         // add date selection
         Container.get<Select>(DateSelect).init();
         // add class selection
@@ -35,6 +48,7 @@ export class BRHeatMapPage extends Page {
         // colorblind mode checkbox
         Container.get<Checkbox>(ColorblindCheckbox).init();
         // init main content plot
+        Container.rebind(Content).toConstantValue(d3.select("#legacy-heatmap-wrapper"));
         // rebind the container to BrHeatmap constructor to new a object
         Container.rebind(BrHeatmap).toSelf();
         this.plot = Container.get(BrHeatmap);
@@ -54,6 +68,16 @@ export class BRHeatMapPage extends Page {
                 localStorage.setItem("colorblind-checkbox", d3.select("#colorblind-checkbox").property("checked").toString())
                 await this.plot.update(false)
             });
+
+        const viewSelect = document.getElementById("view-mode-selection") as HTMLSelectElement;
+        const applyView = () => {
+            const heatmapMode = viewSelect && viewSelect.value === "heatmap";
+            resultsWrapper.hidden = heatmapMode;
+            heatmapWrapper.hidden = !heatmapMode;
+        };
+        applyView();
+        utils.setEvent.byIds("view-mode-selection")
+            .onchange(() => applyView());
     }
 
     get date(): string {

--- a/src/app/sidebar/select.ts
+++ b/src/app/sidebar/select.ts
@@ -52,14 +52,22 @@ export class Select extends SideBarElement {
     }
 
     private addData() {
+        const savedValue = localStorage.getItem(this.id);
+        const values = this.data.map(item => item.id);
+        const fallbackValue = values.indexOf(this.defaultSelectId) >= 0 ? this.defaultSelectId : values[0];
+        const selectedValue = savedValue !== null && values.indexOf(savedValue) >= 0 ? savedValue : fallbackValue;
         this.selection
             .selectAll()
             .data(this.data)
             .enter()
             .append<HTMLOptionElement>("option")
             .attr("value", d => d.id)
-            .attr("selected", d => d.id === this.defaultSelectId ? "selected" : undefined)
+            .attr("selected", d => d.id === selectedValue ? "selected" : undefined)
             .html(d => d.text);
+        this.selection.property("value", selectedValue);
+        this.selection.on("change.persist", () => {
+            localStorage.setItem(this.id, String(this.selection.property("value")));
+        });
         return this;
     }
 }
@@ -185,7 +193,18 @@ Container.bind(BrRangeSelect).toDynamicValue(() => {
         .class.add("plot-selection")
         .data.add({id: "0", text: "0"})
         .data.add({id: "1", text: "1"})
-        .default("1");
+        .default("0");
+})
+
+// view mode selection for results-first browsing or legacy heatmap.
+export const ViewModeSelect = Symbol("ViewModeSelect");
+Container.bind(ViewModeSelect).toDynamicValue(() => {
+    return Container.get(SelectBuilder)
+        .id("view-mode-selection")
+        .label("View")
+        .data.add({id: "results", text: "Ground RB results"})
+        .data.add({id: "heatmap", text: "Legacy heatmap"})
+        .default("results");
 })
 
 // scale select for absolute value or percentage

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,6 @@ import { StackedAreaPage } from "./app/page/stacked-area-page";
 import { TodoPage } from "./app/page/todo-page";
 import { WebRepo } from "./app/link/web-repo";
 import { DataRepo } from "./app/link/data-repo";
-import { GithubLink } from "./app/link/github-link";
 import { Logo } from "./app/image/logo";
 import { GithubIssue } from "./app/link/github-issue";
 import { Forum } from "./app/link/forum";
@@ -13,6 +12,6 @@ import { DarkModeToggle } from "./app/link/dark-mode-toggle";
 Application.build
     .withLogo(Logo)
     .withPages(BRHeatMapPage, StackedAreaPage, TodoPage)
-    .withLinks(WebRepo, DataRepo, GithubIssue, Forum, GithubLink, DarkModeToggle)
+    .withLinks(WebRepo, DataRepo, GithubIssue, Forum, DarkModeToggle)
     .class
     .run()


### PR DESCRIPTION
## User-facing changes
- Adds a sidebar-level View selector so Ground RB results and the legacy heatmap are explicit modes instead of both competing for the page.
- Defaults fresh sessions to the Ground RB results view with the filter sidebar collapsed; the Filters button reopens it and persists the user choice.
- Persists sidebar select choices when they are still valid, while falling back safely when old saved values no longer exist.
- Keeps BR range defaulted to 0 for fresh sessions and for Show plot handoff.
- Removes the top-navbar ControlNet/byline link while preserving upstream/source/license attribution in the data source card.
- Clarifies table/comparison labels from G/K and G/D to Frags / battle and Frags / death.
- Adds a low-sample legend for gold table rows.
- Adds recent-search remove/clear controls and comparison remove/clear controls.
- Keeps card grid sizing aligned with the recent StatShark-inspired polish: 4 cards on wide desktop, 3 at medium widths, 2 on small tablets, 1 on mobile.

## Jules reconciliation
- Confirmed PR #15 is already merged into main.
- Recreated the remaining useful ideas from `polish-ground-rb-defaults-17399112026063920970` on a clean `codex/` branch.
- Did not carry over generated data timestamp churn or `npm_output.log`-style artifacts.

## Testing performed
- `npm ci` completed successfully. npm reported existing audit findings: 1 moderate and 9 high vulnerabilities.
- `npm run prepare:data`
- `npm run prepare:images` with 1199 vehicle-page images, 5 slot-thumbnail fallbacks, 0 placeholders.
- `npm run build:pages` passed with existing webpack asset-size warnings.
- `npm run check:dist`
- Local preview smoke test at `http://localhost:4177/`: verified default Results view, collapsed filters, BR range 0, min battles 500, card grid rendering, table header sort, Results/Heatmap toggle, Compare controls, and Show plot switching to the legacy heatmap.

## Limitations / notes
- Generated public data files were restored after verification so this PR stays focused on UX/source changes.
- Webpack size warnings remain existing project warnings and are not introduced by this branch.