### PR TITLE
Fix heatmap access and low-sample table styling

### DIFF
--- a/index.css
+++ b/index.css
@@ -304,10 +304,6 @@ button,
   top:0;
 }
 
-.ground-rb-results tr.low-sample{
-  background:var(--warn);
-}
-
 .ground-panels{
   display:grid;
   grid-template-columns:minmax(0,1fr) minmax(0,1fr);
@@ -730,25 +726,31 @@ input:focus-visible{
   background:var(--row-hover);
 }
 
-.ground-rb-results tr.low-sample{
-  background:color-mix(in srgb, var(--warn) 80%, transparent);
-}
-
 .table-legend{
-  display:flex;
-  align-items:center;
-  gap:8px;
   margin:8px 10px 10px;
   color:var(--muted);
   font-size:.88rem;
 }
 
-.table-legend-swatch{
-  width:18px;
-  height:12px;
-  border:1px solid var(--border);
-  border-radius:3px;
-  background:color-mix(in srgb, var(--warn) 80%, transparent);
+.low-sample-battles{
+  font-weight:900;
+  color:var(--accent-strong);
+}
+
+.empty-results{
+  color:var(--muted);
+  font-weight:700;
+  text-align:center;
+}
+
+.card-empty{
+  grid-column:1 / -1;
+  width:min(100%, 520px);
+  margin:24px auto;
+  padding:18px;
+  border:1px dashed rgba(137,221,255,.28);
+  border-radius:var(--radius);
+  background:rgba(137,221,255,.06);
 }
 
 .ground-rb-results td:first-child button{
@@ -1030,6 +1032,60 @@ input:focus-visible{
 }
 
 /* ---------- Ground RB vehicle card gallery ---------- */
+.mode-switch-bar{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  max-width:1220px;
+  margin:0 0 12px;
+  padding:10px 12px;
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  background:linear-gradient(180deg, color-mix(in srgb, var(--panel) 92%, var(--accent) 8%), var(--panel));
+  color:var(--text);
+  box-shadow:var(--shadow);
+}
+
+.mode-switch-copy{
+  display:flex;
+  flex-direction:column;
+  gap:2px;
+  min-width:0;
+}
+
+.mode-switch-copy strong{
+  color:var(--accent-strong);
+}
+
+.mode-switch-copy span{
+  color:var(--muted);
+  font-size:.9rem;
+}
+
+.mode-switch-toggle{
+  display:flex;
+  flex:0 0 auto;
+  gap:6px;
+  padding:4px;
+  border:1px solid rgba(137,221,255,.2);
+  border-radius:12px;
+  background:rgba(137,221,255,.06);
+}
+
+.mode-switch-toggle button{
+  min-height:38px;
+  min-width:96px;
+  border-color:transparent;
+  background:transparent;
+}
+
+.mode-switch-toggle button[aria-pressed="true"]{
+  background:linear-gradient(180deg, var(--accent-strong), var(--accent));
+  color:var(--accent-text);
+  box-shadow:0 8px 22px rgba(0,119,182,.18);
+}
+
 .results-toolbar{
   display:flex;
   align-items:center;
@@ -1524,6 +1580,21 @@ body.modal-open{
 }
 
 @media (max-width:640px){
+  .mode-switch-bar{
+    align-items:stretch;
+    flex-direction:column;
+  }
+
+  .mode-switch-toggle{
+    width:100%;
+    box-sizing:border-box;
+  }
+
+  .mode-switch-toggle button{
+    flex:1 1 0;
+    min-width:0;
+  }
+
   .results-toolbar,
   .results-toolbar label{
     align-items:stretch;

--- a/src/app/ground-rb-panel.ts
+++ b/src/app/ground-rb-panel.ts
@@ -83,6 +83,7 @@ const STORAGE_FAVORITES = "wt-ground-rb-favorites";
 const STORAGE_COMPARE = "wt-ground-rb-compare";
 const STORAGE_TABLE_SORT = "wt-ground-rb-table-sort";
 const CARD_PAGE_SIZE = 50;
+const LOW_SAMPLE_BATTLES = 400;
 
 type SortMode = "win" | "played" | "gkd" | "gkb" | "brAsc" | "brDesc" | "name";
 type ViewMode = "card" | "table";
@@ -242,7 +243,7 @@ export class GroundRbPanel {
                     </thead>
                     <tbody id="ground-results"></tbody>
                 </table>
-                <p class="table-legend"><span class="table-legend-swatch" aria-hidden="true"></span>Gold rows indicate low sample size; interpret cautiously.</p>
+                <p class="table-legend">Bold Battles values indicate fewer than ${LOW_SAMPLE_BATTLES} battles; interpret cautiously.</p>
             </div>
             <div class="ground-panels">
                 <article id="vehicle-detail" class="vehicle-detail" aria-live="polite"></article>
@@ -251,7 +252,7 @@ export class GroundRbPanel {
             <aside class="source-card">
                 <h3>Data, Source, And License</h3>
                 <p>Fork source: <a href="${this.sourceInfo.forkRepo}">zeoce/wt-data-project.web</a>. Upstream web: <a href="${this.sourceInfo.upstreamWebRepo}">ControlNet/wt-data-project.web</a>. Upstream data: <a href="${this.sourceInfo.upstreamDataRepo}">ControlNet/wt-data-project.data</a>.</p>
-                <p>This AGPL project keeps source availability and upstream attribution visible. Thunderskill-derived data is sample-based, and joined vehicle matching may contain errors. Treat low-sample rows as directional, not definitive.</p>
+                <p>This AGPL project keeps source availability and upstream attribution visible. Thunderskill-derived data is sample-based, and joined vehicle matching may contain errors. Treat low-sample values as directional, not definitive.</p>
                 <p>${this.imageSourceCopy()} Ground frags and deaths on cards are estimates derived from battles and per-battle/per-death rates.</p>
                 <p>Prepared: ${this.formatDate(this.sourceInfo.generatedAt)}. Latest data date: ${latest ? this.escape(latest.date) : "N/A"}.</p>
             </aside>
@@ -429,11 +430,13 @@ export class GroundRbPanel {
         const tableResults = this.tableSort
             ? rankedResults.slice().sort((a, b) => this.compareTableRows(a, b))
             : rankedResults;
-        this.byId("result-count").textContent = `${results.length} vehicles`;
+        this.byId("result-count").textContent = `${results.length} ${results.length === 1 ? "vehicle" : "vehicles"}`;
         this.updateTableSortHeaders();
 
         const tbody = this.byId("ground-results");
-        tbody.innerHTML = tableResults.slice(0, 100).map(item => this.resultRow(item.row, filters.minBattles, item.resultRank)).join("");
+        tbody.innerHTML = tableResults.length
+            ? tableResults.slice(0, 100).map(item => this.resultRow(item.row, item.resultRank)).join("")
+            : `<tr><td class="empty-results" colspan="10">No Ground RB vehicles match the current filters.</td></tr>`;
         Array.prototype.forEach.call(tbody.querySelectorAll("[data-select]"), (button: HTMLButtonElement) => {
             button.addEventListener("click", () => this.selectVehicle(button.getAttribute("data-select")));
         });
@@ -442,24 +445,25 @@ export class GroundRbPanel {
         });
 
         const visible = rankedResults.slice(0, this.visibleCards);
-        this.byId("ground-card-view").innerHTML = visible.map(item => this.vehicleCard(item.row, filters.minBattles, item.resultRank)).join("");
+        this.byId("ground-card-view").innerHTML = visible.length
+            ? visible.map(item => this.vehicleCard(item.row, item.resultRank)).join("")
+            : `<div class="empty-results card-empty">No Ground RB vehicles match the current filters.</div>`;
         this.bindCardButtons(this.byId("ground-card-view"));
         this.debugVisibleImages(visible.map(item => item.row));
         (this.byId("show-more-cards") as HTMLButtonElement).hidden = results.length <= this.visibleCards || this.currentView !== "card";
     }
 
-    private resultRow(row: JoinedRow, minBattles: number, rank: number): string {
-        const battles = this.toNumber(row.rb_battles);
-        const low = battles < minBattles * 2;
+    private resultRow(row: JoinedRow, rank: number): string {
+        const low = this.isLowSample(row);
         const compared = this.compareNames.indexOf(row.name) >= 0;
         return `
-            <tr${low ? " class=\"low-sample\" title=\"Low sample size; interpret cautiously\"" : ""}>
+            <tr>
                 <td><button type="button" data-select="${this.escape(row.name)}">${this.displayName(row)}</button></td>
                 <td>${this.escape(row.nation)}</td>
                 <td>${this.formatValue(row.rb_br)}</td>
                 <td>#${rank}</td>
                 <td>${this.formatPercentage(row.rb_win_rate)}</td>
-                <td>${this.formatCount(row.rb_battles)}</td>
+                <td${low ? ` class="low-sample-battles" title="Fewer than ${LOW_SAMPLE_BATTLES} battles; interpret cautiously"` : ""}>${this.formatCount(row.rb_battles)}</td>
                 <td>${this.formatRatio(row.rb_ground_frags_per_battle)}</td>
                 <td>${this.formatRatio(row.rb_ground_frags_per_death)}</td>
                 <td>${this.isPremium(row) ? "Yes" : "No"}</td>
@@ -468,10 +472,10 @@ export class GroundRbPanel {
         `;
     }
 
-    private vehicleCard(row: JoinedRow, minBattles: number, rank: number): string {
+    private vehicleCard(row: JoinedRow, rank: number): string {
         const compared = this.compareNames.indexOf(row.name) >= 0;
         const favorite = this.favorites.indexOf(row.name) >= 0;
-        const lowSample = this.toNumber(row.rb_battles) < minBattles * 2;
+        const lowSample = this.isLowSample(row);
         return `
             <article class="vehicle-card${this.isPremium(row) ? " premium-card" : ""}${lowSample ? " low-sample-card" : ""}" data-nation="${this.escape(row.nation)}">
                 ${this.vehicleArt(row)}
@@ -494,7 +498,7 @@ export class GroundRbPanel {
                         ${this.stat("SL / game", this.formatCount(row.rb_sl_rate))}
                         ${this.stat("RP / game", this.formatCount(row.rb_rp_rate))}
                     </dl>
-                    <div class="card-caveat-row">${lowSample ? "<p class=\"card-caveat\">Low sample: treat cautiously.</p>" : ""}</div>
+                    <div class="card-caveat-row">${lowSample ? `<p class="card-caveat">Fewer than ${LOW_SAMPLE_BATTLES} battles: interpret cautiously.</p>` : ""}</div>
                     <div class="card-actions">
                         <button type="button" data-select="${this.escape(row.name)}">Details</button>
                         <button type="button" data-compare="${this.escape(row.name)}">${compared ? "Remove" : "Compare"}</button>
@@ -554,7 +558,7 @@ export class GroundRbPanel {
 
     private renderDetail(row: JoinedRow): void {
         const favorites = this.favorites.indexOf(row.name) >= 0;
-        const lowSample = this.toNumber(row.rb_battles) < this.filters().minBattles;
+        const lowSample = this.isLowSample(row);
         this.byId("vehicle-detail").innerHTML = `
             <h3>${this.displayName(row)}</h3>
             <div class="detail-actions">
@@ -573,7 +577,7 @@ export class GroundRbPanel {
                 <dt>Premium</dt><dd>${this.isPremium(row) ? "Yes" : "No"}</dd>
                 <dt>Source update</dt><dd>${this.sourceInfo ? this.escape(this.sourceInfo.latestJoined.date) : "N/A"}</dd>
             </dl>
-            <p class="data-caveat">${lowSample ? "Low sample warning: this row is below the selected battle threshold. " : ""}Thunderskill data is sample-based and joined data can contain vehicle matching errors.</p>
+            <p class="data-caveat">${lowSample ? `Low sample warning: this vehicle has fewer than ${LOW_SAMPLE_BATTLES} battles. ` : ""}Thunderskill data is sample-based and joined data can contain vehicle matching errors.</p>
         `;
         this.byId("favorite-current").addEventListener("click", () => {
             this.toggleName(this.favorites, row.name, STORAGE_FAVORITES, 99);
@@ -948,6 +952,10 @@ export class GroundRbPanel {
         const perDeath = this.toNumber(row.rb_ground_frags_per_death);
         const estimate = perDeath > 0 ? Math.round(frags / perDeath) : 0;
         return estimate > 0 ? `${estimate}` : "N/A";
+    }
+
+    private isLowSample(row: JoinedRow): boolean {
+        return this.toNumber(row.rb_battles) > 0 && this.toNumber(row.rb_battles) < LOW_SAMPLE_BATTLES;
     }
 
     private showLegacyPlot(name: string): void {

--- a/src/app/page/br-heatmap-page.ts
+++ b/src/app/page/br-heatmap-page.ts
@@ -29,6 +29,20 @@ export class BRHeatMapPage extends Page {
         const heatmapWrapper = document.createElement("div");
         heatmapWrapper.id = "legacy-heatmap-wrapper";
         heatmapWrapper.hidden = true;
+        const modeSwitch = document.createElement("div");
+        modeSwitch.className = "mode-switch-bar";
+        modeSwitch.setAttribute("aria-label", "Primary view switcher");
+        modeSwitch.innerHTML = `
+            <div class="mode-switch-copy">
+                <strong>Ground RB workspace</strong>
+                <span id="mode-switch-status">Results mode</span>
+            </div>
+            <div class="mode-switch-toggle" role="group" aria-label="Switch between results and heatmap">
+                <button type="button" id="mode-results" aria-controls="ground-rb-wrapper" aria-pressed="true">Results</button>
+                <button type="button" id="mode-heatmap" aria-controls="legacy-heatmap-wrapper" aria-pressed="false">Heatmap</button>
+            </div>
+        `;
+        content.appendChild(modeSwitch);
         content.appendChild(resultsWrapper);
         content.appendChild(heatmapWrapper);
         new GroundRbPanel(Application.metadata).render(resultsWrapper);
@@ -74,10 +88,51 @@ export class BRHeatMapPage extends Page {
             const heatmapMode = viewSelect && viewSelect.value === "heatmap";
             resultsWrapper.hidden = heatmapMode;
             heatmapWrapper.hidden = !heatmapMode;
+            this.updateModeSwitch(heatmapMode);
+            if (heatmapMode) this.setSidebarCollapsed(false);
         };
         applyView();
         utils.setEvent.byIds("view-mode-selection")
             .onchange(() => applyView());
+        this.bindModeSwitch(viewSelect, applyView);
+    }
+
+    private bindModeSwitch(viewSelect: HTMLSelectElement, applyView: () => void): void {
+        const resultsButton = document.getElementById("mode-results");
+        const heatmapButton = document.getElementById("mode-heatmap");
+        resultsButton?.addEventListener("click", () => {
+            if (viewSelect) viewSelect.value = "results";
+            localStorage.setItem("view-mode-selection", "results");
+            applyView();
+        });
+        heatmapButton?.addEventListener("click", () => {
+            if (viewSelect) viewSelect.value = "heatmap";
+            localStorage.setItem("view-mode-selection", "heatmap");
+            applyView();
+        });
+    }
+
+    private updateModeSwitch(heatmapMode: boolean): void {
+        document.getElementById("mode-results")?.setAttribute("aria-pressed", String(!heatmapMode));
+        document.getElementById("mode-heatmap")?.setAttribute("aria-pressed", String(heatmapMode));
+        const status = document.getElementById("mode-switch-status");
+        if (status) {
+            status.textContent = heatmapMode ? "Heatmap mode: filters and chart controls are in the sidebar" : "Results mode";
+        }
+    }
+
+    private setSidebarCollapsed(collapsed: boolean): void {
+        const sidebar = document.getElementById("sidebar");
+        const main = document.getElementById("main-div");
+        const button = document.getElementById("sidebar-toggle");
+        if (!sidebar) return;
+        sidebar.classList.toggle("collapsed", collapsed);
+        main?.classList.toggle("sidebar-collapsed", collapsed);
+        localStorage.setItem("wt-sidebar-collapsed", String(collapsed));
+        if (button) {
+            button.setAttribute("aria-expanded", String(!collapsed));
+            button.textContent = collapsed ? "Filters" : "Hide filters";
+        }
     }
 
     get date(): string {


### PR DESCRIPTION
## Heatmap access
- The heatmap was technically still accessible before through the sidebar `View` select, but that path was too hidden because the sidebar defaults collapsed.
- Added a persistent Results / Heatmap segmented switch above the main workspace so the access path is obvious even when filters are collapsed.
- Heatmap mode hides the Ground RB results wrapper, shows the legacy heatmap wrapper, syncs the sidebar View select, and opens the sidebar so heatmap controls are visible.
- Results mode hides the legacy heatmap wrapper and restores the card/table results.

## Low-sample treatment
- Removed the gold/brown full-row low-sample styling from the results table.
- Added a fixed low-sample threshold of fewer than 400 RB battles.
- Low-sample table rows now only bold the Battles cell and add a tooltip: `Fewer than 400 battles; interpret cautiously`.
- Updated the table legend and detail/card warning copy to use the `<400 battles` rule.

## Small review tweaks
- Added a no-results empty state for both card and table views.
- Kept the mode switch accessible with `aria-pressed` and `aria-controls`.
- Made the mode switch responsive so it wraps cleanly on mobile.
- Kept AGPL/source attribution unchanged in the source card.

## Files changed
- `src/app/page/br-heatmap-page.ts`
- `src/app/ground-rb-panel.ts`
- `index.css`

## Testing performed
- `npm ci` completed successfully; npm still reports existing audit findings: 1 moderate and 9 high vulnerabilities.
- `npm run prepare:data`
- `npm run prepare:images` with 1199 vehicle-page images, 5 slot-thumbnail fallbacks, 0 placeholders.
- `npm run build:pages` passed with existing webpack asset-size warnings.
- `npm run check:dist`
- Local preview validation on `http://localhost:4180/`:
  - Fresh load shows Results mode with visible Results / Heatmap switch.
  - Sidebar remains collapsed by default on fresh Results load.
  - Heatmap switch shows heatmap and color bar, hides results, syncs sidebar View, and opens filters for heatmap controls.
  - Results switch restores cards/table.
  - Gold/brown low-sample row classes are gone.
  - Battles values under 400 are bold and tooltip-marked.
  - Battles sorting remains numeric.
  - Card view, table view, details, compare, favourite, image preview modal, and mobile mode-switch layout smoke-tested.
  - Browser console error log check returned no errors during the smoke pass.

## Limitations / follow-up ideas
- Webpack asset-size warnings remain existing project warnings and are not addressed here.
- The sidebar View select remains as a secondary/synced control; the new top switch is the primary discovery path.