### PR TITLE
Schedule daily upstream data refresh

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -26,7 +26,9 @@ jobs:
         run: npm ci
 
       - name: Prepare static data
-        run: npm run prepare:data
+        run: |
+          npm run prepare:data
+          npm run prepare:images
 
       - name: Build Cloudflare Pages artifact
         run: npm run build:pages

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,9 @@ jobs:
         run: npm ci
 
       - name: Prepare static data
-        run: npm run prepare:data
+        run: |
+          npm run prepare:data
+          npm run prepare:images
 
       - name: Build Cloudflare Pages artifact
         run: npm run build:pages

--- a/.github/workflows/refresh-data.yaml
+++ b/.github/workflows/refresh-data.yaml
@@ -1,0 +1,58 @@
+name: refresh upstream data
+
+on:
+  schedule:
+    # GitHub schedules are UTC. 13:00 UTC is 6am in Vancouver during daylight time.
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-upstream-data
+  cancel-in-progress: false
+
+jobs:
+  refresh-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Refresh public data
+        run: |
+          npm run prepare:data
+          npm run prepare:images
+
+      - name: Validate Cloudflare Pages build
+        run: |
+          npm run build:pages
+          npm run check:dist
+        env:
+          CI: true
+
+      - name: Commit refreshed data
+        run: |
+          if git diff --quiet -I '"generatedAt":' -- public/data; then
+            echo "No upstream data changes detected."
+            git restore -- public/data
+            exit 0
+          fi
+
+          latest_date="$(node -e "const fs=require('fs'); const s=JSON.parse(fs.readFileSync('public/data/source-info.json','utf8')); console.log(s.latestJoined.date)")"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add public/data/latest-joined.csv public/data/metadata.json public/data/source-info.json public/data/vehicle-images.json
+          git commit -m "Refresh public data to ${latest_date}"
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Manual image corrections can be added to `scripts/vehicle-image-overrides.json` 
 }
 ```
 
+### Scheduled Data Refresh
+
+`.github/workflows/refresh-data.yaml` refreshes upstream data every day at `13:00 UTC`, which is 6am in Vancouver during daylight time. The workflow can also be run manually from GitHub Actions. It runs `prepare:data`, `prepare:images`, `build:pages`, and `check:dist`, then commits the regenerated `public/data/*` files directly to `main` only when upstream data has changed. A successful commit to `main` triggers Cloudflare Pages to rebuild and publish the refreshed dataset.
+
+GitHub cron schedules are UTC-only, so the run time will be one hour different during standard time unless the cron is adjusted.
+
 ### Cloudflare Pages Troubleshooting
 
 - Blank app shell: confirm `dist/index.html`, `dist/bundle.js`, `dist/index.css`, and `dist/config/params.json` are present and served with the expected content types.


### PR DESCRIPTION
## Summary
- Adds a scheduled GitHub Actions workflow to refresh upstream public data daily.
- Runs at `13:00 UTC`, which is 6am in Vancouver during daylight time.
- Supports manual `workflow_dispatch` runs from GitHub Actions.
- Runs data prep, image prep, Pages build, and dist validation before committing.
- Commits regenerated `public/data/*` directly to `main` only when there are real upstream data changes, ignoring generated timestamp-only diffs.
- Makes existing build workflows explicitly run `prepare:images` before building.
- Documents the scheduled refresh behavior in the README.

## Testing
- `npm run prepare:data`
- `npm run prepare:images`
- `npm run build:pages`
- `npm run check:dist`

## Notes
- GitHub cron is UTC-only; this is 6am Vancouver during daylight time and 5am during standard time unless adjusted later.
- Build still reports the existing webpack asset-size warnings.