### PR TITLE
Improve heatmap readability and layout

### DIFF
--- a/config/params.json
+++ b/config/params.json
@@ -1,24 +1,24 @@
 {
   "BrHeatmapPage": {
     "BrHeatmap": {
-      "svgHeight": 800,
-      "svgWidth": 600,
+      "svgHeight": 780,
+      "svgWidth": 980,
       "margin": {
-        "top": 20,
-        "right": 30,
-        "bottom": 40,
-        "left": 100
+        "top": 28,
+        "right": 28,
+        "bottom": 56,
+        "left": 74
       },
       "mainSvgId": "main-svg"
     },
     "ColorBar": {
-      "svgHeight": 800,
-      "svgWidth": 60,
+      "svgHeight": 780,
+      "svgWidth": 112,
       "margin": {
-        "top": 20,
-        "right": 40,
-        "bottom": 40,
-        "left": 0
+        "top": 28,
+        "right": 54,
+        "bottom": 56,
+        "left": 12
       }
     },
     "BrLineChart": {

--- a/index.css
+++ b/index.css
@@ -2475,3 +2475,132 @@ button:hover,
   }
 }
 
+/* ---------- Heatmap readability pass ---------- */
+#legacy-heatmap-wrapper{
+  max-width:1440px;
+}
+
+.heatmap-panel{
+  border:1px solid var(--border);
+  border-radius:14px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel) 92%, var(--accent) 8%), var(--panel));
+  box-shadow:var(--shadow);
+  overflow:hidden;
+}
+
+.heatmap-panel-head{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:20px;
+  padding:18px 20px;
+  border-bottom:1px solid var(--border);
+  background:color-mix(in srgb, var(--panel) 88%, var(--ink) 12%);
+}
+
+.heatmap-panel-head h2{
+  margin:6px 0 0;
+  color:var(--text);
+  font-size:1.42rem;
+  line-height:1.1;
+}
+
+.heatmap-panel-head p{
+  max-width:620px;
+  margin:0;
+  color:var(--muted);
+  font-weight:700;
+}
+
+.heatmap-visualization{
+  display:flex;
+  flex-wrap:wrap;
+  align-items:flex-start;
+  justify-content:center;
+  gap:0;
+  padding:20px;
+  overflow:auto;
+  -webkit-overflow-scrolling:touch;
+}
+
+#main-svg,
+#color-bar-svg{
+  flex:0 0 auto;
+  background:#111916;
+}
+
+#main-svg{
+  margin:0;
+  border:1px solid rgba(255,255,255,.13);
+  border-right:0;
+  border-radius:12px 0 0 12px;
+  box-shadow:none;
+}
+
+#color-bar-svg{
+  margin:0;
+  border:1px solid rgba(255,255,255,.13);
+  border-left:0;
+  border-radius:0 12px 12px 0;
+  box-shadow:none;
+}
+
+#line-chart-svg,
+#legend-svg{
+  flex:0 0 auto;
+  margin-top:20px;
+  background:#111916;
+}
+
+#main-svg .heatmap-axis text,
+#color-bar-svg .legend-axis text{
+  fill:#dbe7df;
+  font-weight:800;
+}
+
+#main-svg .heatmap-axis line,
+#color-bar-svg .legend-axis line{
+  stroke:rgba(219,231,223,.52);
+}
+
+#main-svg .heatmap-axis path,
+#color-bar-svg .legend-axis path{
+  stroke:rgba(219,231,223,.32);
+}
+
+#main-svg rect{
+  shape-rendering:geometricPrecision;
+  transition:stroke-width .12s ease, stroke .12s ease, filter .12s ease;
+}
+
+#main-svg rect.is-empty-cell{
+  opacity:.58;
+}
+
+#main-svg rect.is-hovered{
+  stroke:#f7fbf6 !important;
+  stroke-width:3px !important;
+  filter:brightness(1.08);
+}
+
+#main-svg rect.is-selected{
+  stroke:#ffffff !important;
+  stroke-width:4px !important;
+  filter:drop-shadow(0 0 5px rgba(255,255,255,.45));
+}
+
+#selected-table-div{
+  flex:1 1 100%;
+}
+
+@media (max-width:1180px){
+  .heatmap-panel-head{
+    flex-direction:column;
+  }
+
+  .heatmap-visualization{
+    justify-content:flex-start;
+  }
+}
+

--- a/src/app/page/br-heatmap-page.ts
+++ b/src/app/page/br-heatmap-page.ts
@@ -29,7 +29,19 @@ export class BRHeatMapPage extends Page {
         const heatmapWrapper = document.createElement("div");
         heatmapWrapper.id = "legacy-heatmap-wrapper";
         heatmapWrapper.hidden = true;
-        heatmapWrapper.innerHTML = `<p id="heatmap-data-status" class="heatmap-data-status" role="status" hidden></p>`;
+        heatmapWrapper.innerHTML = `
+            <section class="heatmap-panel" aria-label="Battle rating heatmap">
+                <div class="heatmap-panel-head">
+                    <div>
+                        <span class="eyebrow">Legacy heatmap</span>
+                        <h2>BR balance matrix</h2>
+                    </div>
+                    <p>Use the sidebar to change date, class, mode, measurement, BR range, and colorblind mode. Click cells to compare trends below.</p>
+                </div>
+                <p id="heatmap-data-status" class="heatmap-data-status" role="status" hidden></p>
+                <div id="heatmap-visualization" class="heatmap-visualization"></div>
+            </section>
+        `;
         const modeSwitch = document.createElement("div");
         modeSwitch.className = "mode-switch-bar";
         modeSwitch.setAttribute("aria-label", "Primary view switcher");
@@ -63,7 +75,7 @@ export class BRHeatMapPage extends Page {
         // colorblind mode checkbox
         Container.get<Checkbox>(ColorblindCheckbox).init();
         // init main content plot
-        Container.rebind(Content).toConstantValue(d3.select("#legacy-heatmap-wrapper"));
+        Container.rebind(Content).toConstantValue(d3.select("#heatmap-visualization"));
         // rebind the container to BrHeatmap constructor to new a object
         Container.rebind(BrHeatmap).toSelf();
         this.plot = Container.get(BrHeatmap);

--- a/src/misc/color-map-def.ts
+++ b/src/misc/color-map-def.ts
@@ -1,4 +1,4 @@
-import { CONT_COLORS, CONT_COLORS_BLIND, Container } from "../utils";
+import { Container } from "../utils";
 import * as d3 from "d3";
 
 export class ColorMap {
@@ -21,77 +21,91 @@ export class BrHeatColorMap {
 }
 
 const getBrHeatmapColorMaps: (isColorblind: boolean) => BrHeatColorMap = (isColorblind) => {
-    const colors = isColorblind ? CONT_COLORS_BLIND : CONT_COLORS;
+    const colors = isColorblind
+        ? {
+            RED: "#5F55B5",
+            YELLOW: "#D7B84F",
+            GREEN: "#2CA25F",
+            DEEP: "#2A2238",
+            PEAK: "#D9F0A3"
+        }
+        : {
+            RED: "#B63F5A",
+            YELLOW: "#D59D35",
+            GREEN: "#3DBD82",
+            DEEP: "#332033",
+            PEAK: "#C9E86A"
+        };
     return {
         "winRate": {
             "Ground_vehicles": new ColorMap(
                 "ground-vehicles-win-rate",
-                [colors.BLACK, colors.BLACK, colors.RED, colors.YELLOW, colors.GREEN, colors.BLACK, colors.BLACK],
+                [colors.DEEP, colors.DEEP, colors.RED, colors.YELLOW, colors.GREEN, colors.PEAK, colors.PEAK],
                 [0, 0.05, 0.43, 0.53, 0.63, 0.95, 1.0]
             ),
             "Aviation": new ColorMap(
                 "aviation-win-rate",
-                [colors.BLACK, colors.BLACK, colors.RED, colors.YELLOW, colors.GREEN, colors.BLACK, colors.BLACK],
+                [colors.DEEP, colors.DEEP, colors.RED, colors.YELLOW, colors.GREEN, colors.PEAK, colors.PEAK],
                 [0, 0.01, 0.5, 0.6, 0.7, 0.99, 1.0]
             )
         },
         "battlesSum": {
             "Ground_vehicles": new ColorMap(
                 "ground-vehicles-battles-sum",
-                [colors.BLACK, colors.BLACK, colors.RED, colors.YELLOW, colors.GREEN, colors.BLACK, colors.BLACK],
+                [colors.DEEP, colors.DEEP, colors.RED, colors.YELLOW, colors.GREEN, colors.PEAK, colors.PEAK],
                 [0, 0.01, 0.4, 0.5, 0.6, 0.99, 1.0],
             ),
             "Aviation": new ColorMap(
                 "aviation-battles-sum",
-                [colors.BLACK, colors.BLACK, colors.RED, colors.YELLOW, colors.GREEN, colors.BLACK, colors.BLACK],
+                [colors.DEEP, colors.DEEP, colors.RED, colors.YELLOW, colors.GREEN, colors.PEAK, colors.PEAK],
                 [0, 0.01, 0.4, 0.5, 0.6, 0.99, 1.0],
             )
         },
         "airFragsPerBattle": {
             "Ground_vehicles": new ColorMap(
                 "ground-vehicles-air-frags-per-battle",
-                [colors.BLACK, colors.BLACK, colors.RED, colors.YELLOW, colors.GREEN, colors.BLACK, colors.BLACK],
+                [colors.DEEP, colors.DEEP, colors.RED, colors.YELLOW, colors.GREEN, colors.PEAK, colors.PEAK],
                 [0, 0.001, 0.01, 0.025, 0.05, 0.999, 1.0],
             ),
             "Aviation": new ColorMap(
                 "aviation-air-frags-per-battle",
-                [colors.BLACK, colors.BLACK, colors.RED, colors.YELLOW, colors.GREEN, colors.BLACK, colors.BLACK],
+                [colors.DEEP, colors.DEEP, colors.RED, colors.YELLOW, colors.GREEN, colors.PEAK, colors.PEAK],
                 [0, 0.001, 0.07, 0.13, 0.25, 0.999, 1.0],
             )
         },
         "airFragsPerDeath": {
             "Ground_vehicles": new ColorMap(
                 "ground-vehicles-air-frags-per-death",
-                [colors.BLACK, colors.BLACK, colors.RED, colors.YELLOW, colors.GREEN, colors.BLACK, colors.BLACK],
+                [colors.DEEP, colors.DEEP, colors.RED, colors.YELLOW, colors.GREEN, colors.PEAK, colors.PEAK],
                 [0, 0.001, 0.01, 0.025, 0.05, 0.999, 1.0],
             ),
             "Aviation": new ColorMap(
                 "aviation-air-frags-per-death",
-                [colors.BLACK, colors.BLACK, colors.RED, colors.YELLOW, colors.GREEN, colors.BLACK, colors.BLACK],
+                [colors.DEEP, colors.DEEP, colors.RED, colors.YELLOW, colors.GREEN, colors.PEAK, colors.PEAK],
                 [0, 0.001, 0.07, 0.13, 0.25, 0.999, 1.0],
             )
         },
         "groundFragsPerBattle": {
             "Ground_vehicles": new ColorMap(
                 "ground-vehicles-ground-frags-per-battle",
-                [colors.BLACK, colors.BLACK, colors.RED, colors.YELLOW, colors.GREEN, colors.BLACK, colors.BLACK],
+                [colors.DEEP, colors.DEEP, colors.RED, colors.YELLOW, colors.GREEN, colors.PEAK, colors.PEAK],
                 [0, 0.001, 0.1, 0.2, 0.3, 0.999, 1.0],
             ),
             "Aviation": new ColorMap(
                 "aviation-ground-frags-per-battle",
-                [colors.BLACK, colors.BLACK, colors.RED, colors.YELLOW, colors.GREEN, colors.BLACK, colors.BLACK],
+                [colors.DEEP, colors.DEEP, colors.RED, colors.YELLOW, colors.GREEN, colors.PEAK, colors.PEAK],
                 [0, 0.001, 0.01, 0.05, 0.3, 0.999, 1.0],
             )
         },
         "groundFragsPerDeath": {
             "Ground_vehicles": new ColorMap(
                 "ground-vehicles-ground-frags-per-death",
-                [colors.BLACK, colors.BLACK, colors.RED, colors.YELLOW, colors.GREEN, colors.BLACK, colors.BLACK],
+                [colors.DEEP, colors.DEEP, colors.RED, colors.YELLOW, colors.GREEN, colors.PEAK, colors.PEAK],
                 [0, 0.001, 0.1, 0.2, 0.3, 0.999, 1.0],
             ),
             "Aviation": new ColorMap(
                 "aviation-ground-frags-per-death",
-                [colors.BLACK, colors.BLACK, colors.RED, colors.YELLOW, colors.GREEN, colors.BLACK, colors.BLACK],
+                [colors.DEEP, colors.DEEP, colors.RED, colors.YELLOW, colors.GREEN, colors.PEAK, colors.PEAK],
                 [0, 0.001, 0.01, 0.05, 0.3, 0.999, 1.0],
             )
         }

--- a/src/plot/br-heatmap.ts
+++ b/src/plot/br-heatmap.ts
@@ -2,7 +2,7 @@ import * as d3 from "d3";
 import * as _ from "lodash";
 import { Plot } from "./plot";
 import { TimeseriesData, TimeseriesRow, TimeseriesRowGetter } from "../data/timeseries-data";
-import { categoricalColors, COLORS, CONT_COLORS, Container, Inject, MousePosition, Provider, utils } from "../utils";
+import { categoricalColors, COLORS, Container, Inject, MousePosition, Provider, utils } from "../utils";
 import { ColorBar } from "./color-bar";
 import { BrLineChart, BrLineChartDataObj } from "./line-chart";
 import { BrHeatmapLegend } from "./legend";
@@ -16,6 +16,8 @@ import { Nation } from "../data/wiki-data";
 import { BrHeatColorMap } from "../misc/color-map-def";
 
 const MIN_USABLE_HEATMAP_CELLS = 40;
+const HEATMAP_EMPTY_COLOR = "#2A322E";
+const HEATMAP_CELL_STROKE = "rgba(255,255,255,0.22)";
 
 @Provider(BrHeatmap)
 export class BrHeatmap extends Plot {
@@ -47,12 +49,13 @@ export class BrHeatmap extends Plot {
     }
 
     onPointerLeave(_: SquareInfo, node: SVGRectElement): void {
-        d3.select(node).style("stroke", "black");
+        d3.select(node).classed("is-hovered", false);
         this.tooltip.hide();
     }
 
     onPointerOver(d: SquareInfo, node: SVGRectElement): void {
-        d3.select(node).style("stroke", "white");
+        if (d.value <= 0) return;
+        d3.select(node).classed("is-hovered", true);
         this.tooltip.appear();
         this.tooltip.rect
             .transition()
@@ -61,6 +64,7 @@ export class BrHeatmap extends Plot {
     }
 
     async onPointerMove(d: SquareInfo, node: SVGRectElement): Promise<void> {
+        if (d.value <= 0) return;
         await this.tooltip.update([
             `${Container.get(Localization.BrHeatmapPage.Tooltip.nation)}${Container.get<NationTranslator>(Localization.Nation)(d.nation)}`,
             `${Container.get(Localization.BrHeatmapPage.Tooltip.br)}${d.br}`,
@@ -74,15 +78,16 @@ export class BrHeatmap extends Plot {
     async onClick(_: SquareInfo, node: SVGRectElement): Promise<void> {
         const square: d3.Selection<SVGRectElement, SquareInfo, HTMLElement, any> = d3.select(node);
         const info: SquareInfo = square.data()[0];
+        if (info.value <= 0) return;
 
-        if (utils.rgbToHex(square.style("fill")).toUpperCase() === COLORS.AZURE) {
+        if (square.classed("is-selected")) {
             // if the square is selected
-            square.style("fill", this.value2color(info.value));
+            square.classed("is-selected", false);
             // remove the item in the `this.selected`
             this.selected = this.selected.filter(each => each.br !== info.br || each.nation !== info.nation);
         } else {
             // if the square is not selected
-            square.style("fill", COLORS.AZURE);
+            square.classed("is-selected", true);
             // add the item into the `this.selected`
             this.selected.push(info);
         }
@@ -211,8 +216,10 @@ export class BrHeatmap extends Plot {
 
         const entered = rects.enter()
             .append<SVGRectElement>("rect")
+            .attr("rx", 3)
+            .attr("ry", 3)
             .style("stroke-width", 1)
-            .style("stroke", "black")
+            .style("stroke", HEATMAP_CELL_STROKE)
             .on("pointerover", utils.eventWrapper<SVGRectElement, typeof this.onPointerOver>(this, this.onPointerOver))
             .on("pointerleave", utils.eventWrapper<SVGRectElement, typeof this.onPointerLeave>(this, this.onPointerLeave))
             .on("pointermove", utils.eventWrapper<SVGRectElement, typeof this.onPointerMove>(this, this.onPointerMove))
@@ -226,8 +233,11 @@ export class BrHeatmap extends Plot {
             .attr("y", d => y(d.br))
             .attr("width", squareWidth)
             .attr("height", squareHeight)
+            .classed("is-empty-cell", d => d.value <= 0)
+            .classed("is-selected", d => this.selected.some(each => each.br === d.br && each.nation === d.nation))
             .style("stroke-width", 1)
-            .style("stroke", "black");
+            .style("stroke", HEATMAP_CELL_STROKE)
+            .style("cursor", d => d.value > 0 ? "pointer" : "default");
 
         if (transition) {
             merged.transition()
@@ -256,6 +266,7 @@ export class BrHeatmap extends Plot {
         // x-axis
         this.g.append("g")
             .attr("id", "br-heatmap-x")
+            .attr("class", "heatmap-axis heatmap-axis-x")
             .style("font-size", 13)
             .attr("transform", `translate(0, ${this.height + 10})`)
             .call(d3.axisBottom(x).tickSize(0)
@@ -265,7 +276,8 @@ export class BrHeatmap extends Plot {
         // y-axis
         this.g.append("g")
             .attr("id", "br-heatmap-y")
-            .style("font-size", 15)
+            .attr("class", "heatmap-axis heatmap-axis-y")
+            .style("font-size", 14)
             .attr("transform", `translate(-5, 0)`)
             .call(d3.axisLeft(y).tickSize(0))
             .select("#main-g g path.domain").remove()
@@ -400,12 +412,12 @@ export class BrHeatmap extends Plot {
                     range2color = d3.scaleLinear<string, string>()
                         .domain(this.colorMaps.winRate.Ground_vehicles.percentiles)
                         .range(this.colorMaps.winRate.Ground_vehicles.colors)
-                        .interpolate(d3.interpolateHsl)
+                        .interpolate(d3.interpolateRgb)
                 } else if (this.page.clazz === "Aviation") {
                     range2color = d3.scaleLinear<string, string>()
                         .domain(this.colorMaps.winRate.Aviation.percentiles)
                         .range(this.colorMaps.winRate.Aviation.colors)
-                        .interpolate(d3.interpolateHsl)
+                        .interpolate(d3.interpolateRgb)
                 } else {
                     throw new Error(`Invalid clazz ${this.page.clazz} for colorMap win_rate`);
                 }
@@ -421,7 +433,7 @@ export class BrHeatmap extends Plot {
                 range2color = d3.scaleLinear<string, string>()
                     .domain(this.colorMaps.battlesSum.Ground_vehicles.percentiles)
                     .range(this.colorMaps.battlesSum.Ground_vehicles.colors)
-                    .interpolate(d3.interpolateHsl)
+                    .interpolate(d3.interpolateRgb)
                 break;
             case "air_frags_per_battle":
                 valueMin = 0;
@@ -435,12 +447,12 @@ export class BrHeatmap extends Plot {
                     range2color = d3.scaleLinear<string, string>()
                         .domain(this.colorMaps.airFragsPerBattle.Ground_vehicles.percentiles)
                         .range(this.colorMaps.airFragsPerBattle.Ground_vehicles.colors)
-                        .interpolate(d3.interpolateHsl)
+                        .interpolate(d3.interpolateRgb)
                 } else if (this.page.clazz === "Aviation") {
                     range2color = d3.scaleLinear<string, string>()
                         .domain(this.colorMaps.airFragsPerBattle.Aviation.percentiles)
                         .range(this.colorMaps.airFragsPerBattle.Aviation.colors)
-                        .interpolate(d3.interpolateHsl)
+                        .interpolate(d3.interpolateRgb)
                 } else {
                     throw new Error(`Invalid clazz ${this.page.clazz} for colorMap air_frags_per_battle`);
                 }
@@ -457,12 +469,12 @@ export class BrHeatmap extends Plot {
                     range2color = d3.scaleLinear<string, string>()
                         .domain(this.colorMaps.airFragsPerDeath.Ground_vehicles.percentiles)
                         .range(this.colorMaps.airFragsPerDeath.Ground_vehicles.colors)
-                        .interpolate(d3.interpolateHsl)
+                        .interpolate(d3.interpolateRgb)
                 } else if (this.page.clazz === "Aviation") {
                     range2color = d3.scaleLinear<string, string>()
                         .domain(this.colorMaps.airFragsPerDeath.Aviation.percentiles)
                         .range(this.colorMaps.airFragsPerDeath.Aviation.colors)
-                        .interpolate(d3.interpolateHsl)
+                        .interpolate(d3.interpolateRgb)
                 } else {
                     throw new Error(`Invalid clazz ${this.page.clazz} for colorMap air_frags_per_death`);
                 }
@@ -479,12 +491,12 @@ export class BrHeatmap extends Plot {
                     range2color = d3.scaleLinear<string, string>()
                         .domain(this.colorMaps.groundFragsPerBattle.Ground_vehicles.percentiles)
                         .range(this.colorMaps.groundFragsPerBattle.Ground_vehicles.colors)
-                        .interpolate(d3.interpolateHsl)
+                        .interpolate(d3.interpolateRgb)
                 } else if (this.page.clazz === "Aviation") {
                     range2color = d3.scaleLinear<string, string>()
                         .domain(this.colorMaps.groundFragsPerBattle.Aviation.percentiles)
                         .range(this.colorMaps.groundFragsPerBattle.Aviation.colors)
-                        .interpolate(d3.interpolateHsl)
+                        .interpolate(d3.interpolateRgb)
                 } else {
                     throw new Error(`Invalid clazz ${this.page.clazz} for colorMap ground_frags_per_battle`);
                 }
@@ -501,12 +513,12 @@ export class BrHeatmap extends Plot {
                     range2color = d3.scaleLinear<string, string>()
                         .domain(this.colorMaps.groundFragsPerDeath.Ground_vehicles.percentiles)
                         .range(this.colorMaps.groundFragsPerDeath.Ground_vehicles.colors)
-                        .interpolate(d3.interpolateHsl)
+                        .interpolate(d3.interpolateRgb)
                 } else if (this.page.clazz === "Aviation") {
                     range2color = d3.scaleLinear<string, string>()
                         .domain(this.colorMaps.groundFragsPerDeath.Aviation.percentiles)
                         .range(this.colorMaps.groundFragsPerDeath.Aviation.colors)
-                        .interpolate(d3.interpolateHsl)
+                        .interpolate(d3.interpolateRgb)
                 } else {
                     throw new Error(`Invalid clazz ${this.page.clazz} for colorMap ground_frags_per_death`);
                 }
@@ -522,7 +534,7 @@ export class BrHeatmap extends Plot {
 
         return (value: number) => {
             if (value == 0.) {
-                return COLORS.BLANK;
+                return HEATMAP_EMPTY_COLOR;
             } else {
                 return range2color(value2range(value));
             }

--- a/src/plot/color-bar.ts
+++ b/src/plot/color-bar.ts
@@ -72,8 +72,10 @@ export class ColorBar extends Plot {
         const legendWidth = this.width;
 
         this.g.append<SVGRectElement>('rect')
-            .attr('x1', 0)
-            .attr('y1', 10)
+            .attr('x', 0)
+            .attr('y', 0)
+            .attr('rx', 6)
+            .attr('ry', 6)
             .attr('width', legendWidth)
             .attr('height', legendHeight)
             .style('fill', `url(#${gradientId})`);
@@ -90,10 +92,13 @@ export class ColorBar extends Plot {
                 .range([legendHeight, 0])
         }
 
-        let legendAxis = d3.axisRight(legendScale);
+        let legendAxis = d3.axisRight(legendScale)
+            .tickSize(4);
 
         if (scale === "log") {
             legendAxis = legendAxis.ticks(3);
+        } else {
+            legendAxis = legendAxis.ticks(6);
         }
 
         legendAxis = legendAxis
@@ -110,7 +115,7 @@ export class ColorBar extends Plot {
         this.g.append("g")
             .style("font-size", scale === "log" ? 12 : null)
             .attr("class", "legend-axis")
-            .attr("transform", "translate(" + legendWidth + ", 0)")
+            .attr("transform", "translate(" + (legendWidth + 4) + ", 0)")
             .call(legendAxis);
 
         return this;


### PR DESCRIPTION
## Summary
- Enlarges the BR heatmap SVG and color legend for easier scanning on desktop.
- Wraps the legacy heatmap in a clearer panel with a heading, usage copy, and dedicated scrollable visualization area.
- Replaces the harsh black/red/yellow/green extremes with a softer low-to-high palette and RGB interpolation.
- Adds a colorblind-specific palette with calmer contrast.
- Makes empty cells neutral/dim instead of bright white.
- Keeps selected cells data-colored and adds strong hover/selection outlines instead of replacing selected cells with blue.
- Rounds heatmap cells and the color bar, simplifies legend ticks, and improves axis/legend text styling.

## Testing
- `npm ci`
- `npm run prepare:data`
- `npm run prepare:images`
- `npm run build:pages`
- `npm run check:dist`

## Notes
- Build still reports the existing webpack asset-size warnings.
- `npm ci` still reports the existing npm audit findings.
- Headless Chrome screenshot automation timed out locally, so validation was through build/dist checks and code-level SVG/layout review.