### PR TITLE
Improve iPhone mobile layout

### DIFF
--- a/index.css
+++ b/index.css
@@ -2604,3 +2604,339 @@ button:hover,
   }
 }
 
+/* ---------- iPhone/mobile usability pass ---------- */
+@media (max-width:560px){
+  html,
+  body{
+    width:100%;
+    max-width:100%;
+    overflow-x:hidden;
+  }
+
+  body{
+    font-size:15px;
+  }
+
+  ul#navbar{
+    min-height:52px;
+    flex-wrap:nowrap;
+    gap:4px;
+    padding:6px max(10px, env(safe-area-inset-left)) 6px max(10px, env(safe-area-inset-right));
+    overflow-x:auto;
+    overflow-y:hidden;
+    scrollbar-width:none;
+    -webkit-overflow-scrolling:touch;
+  }
+
+  ul#navbar::-webkit-scrollbar{
+    display:none;
+  }
+
+  ul#navbar>li{
+    flex:0 0 auto;
+  }
+
+  ul#navbar>li>a,
+  ul#navbar>li>label{
+    min-height:40px;
+    padding:9px 10px;
+    white-space:nowrap;
+    font-size:.86rem;
+  }
+
+  #nav-logo{
+    width:30px;
+    padding-right:6px;
+  }
+
+  #main-div{
+    display:block;
+    width:100%;
+    max-width:100%;
+    margin:0;
+  }
+
+  #content{
+    width:100%;
+    max-width:100%;
+    box-sizing:border-box;
+    padding:10px max(10px, env(safe-area-inset-right)) 28px max(10px, env(safe-area-inset-left));
+    overflow-x:hidden;
+  }
+
+  .sidebar-toggle-btn{
+    position:sticky;
+    top:58px;
+    z-index:15;
+    width:calc(100% - 20px);
+    margin:8px 10px;
+  }
+
+  #sidebar{
+    position:static;
+    display:grid;
+    grid-template-columns:1fr;
+    width:auto;
+    max-width:none;
+    box-sizing:border-box;
+    margin:8px 10px 12px;
+    padding:12px;
+  }
+
+  #sidebar.collapsed{
+    display:none;
+    max-width:0;
+    margin:0;
+    padding:0;
+  }
+
+  #sidebar select,
+  #sidebar input,
+  .filter-grid input,
+  .filter-grid select,
+  .results-toolbar select{
+    min-height:44px;
+    font-size:16px;
+  }
+
+  .mode-switch-bar{
+    position:static;
+    align-items:stretch;
+    flex-direction:column;
+    gap:10px;
+    margin-bottom:10px;
+  }
+
+  .mode-switch-toggle,
+  .view-toggle{
+    width:100%;
+    box-sizing:border-box;
+  }
+
+  .mode-switch-toggle button,
+  .view-toggle button{
+    flex:1 1 0;
+    min-width:0;
+    min-height:42px;
+  }
+
+  .workspace-hero{
+    display:block;
+    margin-bottom:12px;
+  }
+
+  .workspace-hero-copy{
+    min-height:0;
+    padding:20px;
+    border-radius:14px 14px 0 0;
+  }
+
+  .workspace-hero h1{
+    font-size:2.15rem;
+    line-height:1;
+  }
+
+  .workspace-hero p{
+    font-size:.96rem;
+  }
+
+  .workspace-metrics{
+    grid-template-columns:1fr 1fr;
+    border-radius:0 0 14px 14px;
+    border-top:0;
+  }
+
+  .workspace-metrics div{
+    min-height:88px;
+    padding:13px;
+  }
+
+  .workspace-metrics dd{
+    font-size:1.28rem;
+  }
+
+  .ground-rb-filters summary{
+    gap:4px;
+    padding:14px;
+  }
+
+  .ground-rb-filters summary small{
+    font-size:.76rem;
+  }
+
+  .ground-rb-intro,
+  .filter-grid,
+  .search-memory{
+    padding-left:12px;
+    padding-right:12px;
+  }
+
+  .preset-bar{
+    flex-wrap:nowrap;
+    overflow-x:auto;
+    padding-bottom:4px;
+    -webkit-overflow-scrolling:touch;
+  }
+
+  .preset-bar button{
+    flex:0 0 auto;
+    min-height:40px;
+    white-space:nowrap;
+  }
+
+  .filter-grid,
+  .search-memory{
+    grid-template-columns:1fr;
+  }
+
+  .search-memory>div{
+    min-height:48px;
+  }
+
+  .results-toolbar{
+    align-items:stretch;
+    flex-direction:column;
+    gap:12px;
+    margin:12px 0;
+    padding:13px;
+  }
+
+  .results-controls,
+  .results-toolbar label{
+    align-items:stretch;
+    flex-direction:column;
+    width:100%;
+  }
+
+  .results-title strong{
+    font-size:1.25rem;
+  }
+
+  .ground-card-view{
+    grid-template-columns:minmax(0,1fr);
+    max-width:100%;
+    gap:14px;
+    margin:14px 0;
+  }
+
+  .vehicle-card{
+    border-radius:12px;
+  }
+
+  .vehicle-art{
+    min-height:148px;
+  }
+
+  .vehicle-card-body{
+    padding:12px;
+  }
+
+  .vehicle-card h3{
+    min-height:0;
+    font-size:1rem;
+  }
+
+  .badge-row{
+    min-height:0;
+  }
+
+  .stat-grid{
+    grid-template-columns:1fr 1fr;
+  }
+
+  .stat-grid div{
+    padding:8px;
+  }
+
+  .card-actions{
+    grid-template-columns:1fr 1fr;
+  }
+
+  .card-actions button{
+    min-height:44px;
+    font-size:.9rem;
+  }
+
+  .ground-rb-results-wrap{
+    max-width:100%;
+    overflow-x:auto;
+    -webkit-overflow-scrolling:touch;
+  }
+
+  .ground-panels{
+    grid-template-columns:1fr;
+    gap:12px;
+    margin-top:12px;
+  }
+
+  .vehicle-detail,
+  .vehicle-compare,
+  .source-card{
+    padding:14px;
+  }
+
+  .vehicle-detail dl{
+    grid-template-columns:1fr;
+    gap:4px;
+  }
+
+  .vehicle-detail dd{
+    margin:0 0 8px;
+  }
+
+  .heatmap-panel{
+    border-radius:12px;
+  }
+
+  .heatmap-panel-head{
+    padding:14px;
+    gap:8px;
+  }
+
+  .heatmap-panel-head h2{
+    font-size:1.18rem;
+  }
+
+  .heatmap-panel-head p{
+    font-size:.86rem;
+  }
+
+  .heatmap-visualization{
+    display:block;
+    max-width:100%;
+    padding:10px;
+    overflow:auto;
+    -webkit-overflow-scrolling:touch;
+  }
+
+  #main-svg,
+  #color-bar-svg,
+  #line-chart-svg,
+  #legend-svg{
+    max-width:none;
+  }
+
+  #main-svg,
+  #color-bar-svg{
+    display:inline-block;
+    vertical-align:top;
+  }
+
+  #selected-table-div{
+    max-width:100%;
+  }
+
+  .vehicle-image-modal{
+    padding:max(10px, env(safe-area-inset-top)) max(10px, env(safe-area-inset-right)) max(10px, env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left));
+  }
+
+  .vehicle-image-dialog{
+    max-height:calc(100dvh - 20px);
+    border-radius:12px;
+  }
+
+  .vehicle-image-preview-frame img{
+    max-height:calc(100dvh - 160px);
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="description" content="A modern War Thunder Ground RB vehicle browser, comparison workspace, and battle rating heatmap.">
   <meta name="keywords" content="War Thunder, WT Data Project, War Thunder Data Project">
   <meta name="author" content="ControlNet">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#071018">
   <title>WT Data Project | Ground RB Intelligence</title>
 


### PR DESCRIPTION
## Summary
- Adds the missing mobile viewport meta tag so iPhone Safari uses the actual device width instead of shrinking a desktop layout.
- Adds an iPhone/mobile override layer for <=560px screens, including iPhone 13 Pro Max.
- Makes the top nav horizontally scrollable with safe-area padding.
- Makes the sidebar/filter controls single-column, touch-friendly, and collapsible without layout spillover.
- Tightens the workspace hero, metrics, filters, results toolbar, cards, detail/compare panels, modal, and source card for mobile.
- Keeps data tables and the heatmap usable by scrolling inside their own containers rather than forcing page-wide horizontal overflow.
- Uses 16px inputs on mobile to avoid iOS zooming form fields.

## Testing
- `npm ci`
- `npm run prepare:data`
- `npm run prepare:images`
- `npm run build:pages`
- `npm run check:dist`
- Local static preview served successfully.
- Verified built `index.html` contains `viewport` with `width=device-width, initial-scale=1, viewport-fit=cover`.
- Verified built CSS contains the iPhone/mobile override layer.

## Notes
- Build still reports the existing webpack asset-size warnings.
- `npm ci` still reports the existing npm audit findings.
- Headless screenshot automation was unreliable locally, so this pass was validated through build artifacts and static/mobile CSS review.