### PR TITLE
Remove hero section and fix mobile heatmap legend

### DIFF
--- a/index.css
+++ b/index.css
@@ -2907,6 +2907,7 @@ button:hover,
     padding:10px;
     overflow:auto;
     -webkit-overflow-scrolling:touch;
+    white-space:nowrap;
   }
 
   #main-svg,

--- a/src/app/ground-rb-panel.ts
+++ b/src/app/ground-rb-panel.ts
@@ -168,22 +168,7 @@ export class GroundRbPanel {
 
     private renderLoaded(): void {
         const latest = this.sourceInfo ? this.sourceInfo.latestJoined : null;
-        const premiumCount = this.rows.filter(row => this.isPremium(row)).length;
-        const imageCount = this.imageManifest ? this.imageManifest.stats.vehiclePageImages + this.imageManifest.stats.slotThumbnails : 0;
         this.root.innerHTML = `
-            <header class="workspace-hero">
-                <div class="workspace-hero-copy">
-                    <span class="eyebrow">War Thunder Ground RB</span>
-                    <h1>Vehicle intelligence workspace</h1>
-                    <p>Browse the live forked data set, compare vehicles, inspect sample quality, and jump into the legacy BR heatmap when you need the bigger picture.</p>
-                </div>
-                <dl class="workspace-metrics" aria-label="Ground RB data summary">
-                    ${this.heroMetric("Vehicles", this.rows.length.toLocaleString("en-US"), "Ground RB rows")}
-                    ${this.heroMetric("Latest", latest ? latest.date : "N/A", "joined snapshot")}
-                    ${this.heroMetric("Premium", premiumCount.toLocaleString("en-US"), "tagged vehicles")}
-                    ${this.heroMetric("Images", imageCount.toLocaleString("en-US"), "wiki matches")}
-                </dl>
-            </header>
             <details class="ground-rb-filters" open>
                 <summary><span>Filters and presets</span><small>Nation, BR, premium status, sample floor, and search</small></summary>
                 <div class="ground-rb-intro">
@@ -290,16 +275,6 @@ export class GroundRbPanel {
         this.renderMemory();
         this.updateResults();
         this.renderCompare();
-    }
-
-    private heroMetric(label: string, value: string, note: string): string {
-        return `
-            <div>
-                <dt>${this.escape(label)}</dt>
-                <dd>${this.escape(value)}</dd>
-                <small>${this.escape(note)}</small>
-            </div>
-        `;
     }
 
     private bindEvents(): void {


### PR DESCRIPTION
## User-facing changes
- Removed the Ground RB workspace hero/metrics block from the Results view on mobile and desktop.
- Kept the heatmap grid and color legend attached on narrow screens by preventing the paired SVGs from wrapping apart inside the horizontal scroll area.

## Testing performed
- npm ci
- npm run prepare:data
- npm run prepare:images
- npm run build:pages
- npm run check:dist
- Verified the production bundle no longer contains "Vehicle intelligence workspace".
- Verified the production CSS includes the mobile nowrap rule for the heatmap visualization.