### PR TITLE
Keep mobile heatmap legend attached

### DIFF
--- a/index.css
+++ b/index.css
@@ -2524,6 +2524,13 @@ button:hover,
   -webkit-overflow-scrolling:touch;
 }
 
+.heatmap-scroll-pair{
+  display:inline-flex;
+  flex:0 0 auto;
+  align-items:flex-start;
+  white-space:nowrap;
+}
+
 #main-svg,
 #color-bar-svg{
   flex:0 0 auto;
@@ -2908,6 +2915,12 @@ button:hover,
     overflow:auto;
     -webkit-overflow-scrolling:touch;
     white-space:nowrap;
+  }
+
+  .heatmap-scroll-pair{
+    display:inline-flex;
+    max-width:none;
+    vertical-align:top;
   }
 
   #main-svg,

--- a/src/plot/br-heatmap.ts
+++ b/src/plot/br-heatmap.ts
@@ -129,7 +129,12 @@ export class BrHeatmap extends Plot {
 
     init(): BrHeatmap {
         // build new plot in the content div of page
-        this.svg = this.content
+        const heatmapPair = this.content
+            .append<HTMLDivElement>("div")
+            .attr("id", "heatmap-scroll-pair")
+            .attr("class", "heatmap-scroll-pair");
+
+        this.svg = heatmapPair
             .append<SVGSVGElement>("svg")
             .attr("height", this.svgHeight)
             .attr("width", this.svgWidth)

--- a/src/plot/color-bar.ts
+++ b/src/plot/color-bar.ts
@@ -19,7 +19,10 @@ export class ColorBar extends Plot {
     value2color: Value2Color;
 
     init(): ColorBar {
-        this.svg = this.content
+        const heatmapPair = d3.select<HTMLDivElement, unknown>("#heatmap-scroll-pair");
+        const target = heatmapPair.empty() ? this.content : heatmapPair;
+
+        this.svg = target
             .append<SVGSVGElement>("svg")
             .attr("height", this.svgHeight)
             .attr("width", this.svgWidth)


### PR DESCRIPTION
## User-facing changes
- Keeps the heatmap color legend attached to the right side of the heatmap on mobile.
- Adds a dedicated wrapper around the main heatmap SVG and color bar SVG so legacy mobile SVG block rules cannot separate them.

## Testing performed
- npm run build:pages
- npm run check:dist
- Verified built CSS and JS include the new heatmap-scroll-pair wrapper.

## Note
- Attempted local iPhone viewport browser measurement, but local Chrome automation hung in this environment. The fix is structural: the color bar is now appended into the same inline-flex wrapper as the heatmap.