### PR TITLE
Freeze mobile heatmap BR axis

### DIFF
--- a/index.css
+++ b/index.css
@@ -2525,10 +2525,15 @@ button:hover,
 }
 
 .heatmap-scroll-pair{
+  --heatmap-frozen-axis-width:0px;
   display:inline-flex;
   flex:0 0 auto;
   align-items:flex-start;
   white-space:nowrap;
+}
+
+#frozen-br-axis-svg{
+  display:none;
 }
 
 #main-svg,
@@ -2561,18 +2566,21 @@ button:hover,
 }
 
 #main-svg .heatmap-axis text,
-#color-bar-svg .legend-axis text{
+#color-bar-svg .legend-axis text,
+#frozen-br-axis-svg .heatmap-axis text{
   fill:#dbe7df;
   font-weight:800;
 }
 
 #main-svg .heatmap-axis line,
-#color-bar-svg .legend-axis line{
+#color-bar-svg .legend-axis line,
+#frozen-br-axis-svg .heatmap-axis line{
   stroke:rgba(219,231,223,.52);
 }
 
 #main-svg .heatmap-axis path,
-#color-bar-svg .legend-axis path{
+#color-bar-svg .legend-axis path,
+#frozen-br-axis-svg .heatmap-axis path{
   stroke:rgba(219,231,223,.32);
 }
 
@@ -2923,6 +2931,17 @@ button:hover,
     vertical-align:top;
   }
 
+  #frozen-br-axis-svg{
+    display:block;
+    flex:0 0 var(--heatmap-frozen-axis-width);
+    position:sticky;
+    left:0;
+    z-index:6;
+    margin-right:calc(var(--heatmap-frozen-axis-width) * -1);
+    background:#111916;
+    pointer-events:none;
+  }
+
   #main-svg,
   #color-bar-svg,
   #line-chart-svg,
@@ -2934,6 +2953,10 @@ button:hover,
   #color-bar-svg{
     display:inline-block;
     vertical-align:top;
+  }
+
+  #br-heatmap-y{
+    opacity:0;
   }
 
   #selected-table-div{

--- a/src/plot/br-heatmap.ts
+++ b/src/plot/br-heatmap.ts
@@ -33,6 +33,8 @@ export class BrHeatmap extends Plot {
     @Inject(Content) readonly content: d3.Selection<HTMLDivElement, unknown, HTMLElement, any>
     @Inject(BRHeatMapPage) readonly page: BRHeatMapPage;
     colorMaps: BrHeatColorMap | null = null;
+    private frozenAxisSvg!: d3.Selection<SVGSVGElement, unknown, HTMLElement, any>;
+    private frozenAxisG!: d3.Selection<SVGGElement, unknown, HTMLElement, any>;
 
     selected: Array<SquareInfo> = [];
 
@@ -132,7 +134,21 @@ export class BrHeatmap extends Plot {
         const heatmapPair = this.content
             .append<HTMLDivElement>("div")
             .attr("id", "heatmap-scroll-pair")
-            .attr("class", "heatmap-scroll-pair");
+            .attr("class", "heatmap-scroll-pair")
+            .style("--heatmap-frozen-axis-width", `${this.margin.left}px`);
+
+        this.frozenAxisSvg = heatmapPair
+            .append<SVGSVGElement>("svg")
+            .attr("height", this.svgHeight)
+            .attr("width", this.margin.left)
+            .attr("id", "frozen-br-axis-svg")
+            .attr("aria-hidden", "true");
+
+        this.frozenAxisG = this.frozenAxisSvg
+            .append<SVGGElement>("g")
+            .attr("id", "frozen-br-axis-g")
+            .attr("class", "heatmap-axis heatmap-axis-y")
+            .attr("transform", `translate(${this.margin.left - 5}, ${this.margin.top})`);
 
         this.svg = heatmapPair
             .append<SVGSVGElement>("svg")
@@ -286,6 +302,15 @@ export class BrHeatmap extends Plot {
             .attr("transform", `translate(-5, 0)`)
             .call(d3.axisLeft(y).tickSize(0))
             .select("#main-g g path.domain").remove()
+
+        this.frozenAxisG
+            .selectAll("*")
+            .remove();
+        this.frozenAxisG
+            .style("font-size", 14)
+            .call(d3.axisLeft(y).tickSize(0))
+            .select("path.domain")
+            .remove();
         return {x, y};
     }
 


### PR DESCRIPTION
## User-facing changes
- Freezes the BR number axis on small screens while the heatmap scrolls horizontally.
- Keeps the frozen BR labels aligned with the same d3 scale as the main heatmap.
- Hides the original in-SVG y-axis labels on mobile to avoid duplicate labels under the sticky overlay.

## Implementation notes
- Adds a dedicated `frozen-br-axis-svg` inside the existing `heatmap-scroll-pair` wrapper.
- Uses `position: sticky; left: 0` on mobile so BR values remain visible during horizontal scrolling.

## Testing performed
- npm run build:pages
- npm run check:dist
- Verified built JS contains the frozen BR axis creation.
- Verified built CSS contains the mobile sticky axis rules.