### PR TITLE
Add heatmap BR row focus

### DIFF
--- a/index.css
+++ b/index.css
@@ -2586,11 +2586,46 @@ button:hover,
 
 #main-svg rect{
   shape-rendering:geometricPrecision;
-  transition:stroke-width .12s ease, stroke .12s ease, filter .12s ease;
+  transition:opacity .18s ease, stroke-width .12s ease, stroke .12s ease, filter .12s ease;
+}
+
+#main-svg .heatmap-axis-y .tick,
+#frozen-br-axis-svg .heatmap-axis-y .tick{
+  cursor:pointer;
+  outline:none;
+}
+
+#main-svg .heatmap-axis-y .tick text,
+#frozen-br-axis-svg .heatmap-axis-y .tick text{
+  transition:fill .18s ease, opacity .18s ease;
+}
+
+#main-svg .heatmap-axis-y .tick.is-br-dimmed text,
+#frozen-br-axis-svg .heatmap-axis-y .tick.is-br-dimmed text{
+  opacity:.34;
+}
+
+#main-svg .heatmap-axis-y .tick.is-br-focused text,
+#frozen-br-axis-svg .heatmap-axis-y .tick.is-br-focused text{
+  fill:#ffffff;
+}
+
+#main-svg .heatmap-axis-y .tick:focus text,
+#frozen-br-axis-svg .heatmap-axis-y .tick:focus text{
+  fill:var(--accent);
+  text-decoration:underline;
 }
 
 #main-svg rect.is-empty-cell{
   opacity:.58;
+}
+
+#main-svg rect.is-br-dimmed{
+  opacity:.16;
+}
+
+#main-svg rect.is-br-focused{
+  opacity:1;
 }
 
 #main-svg rect.is-hovered{
@@ -2939,7 +2974,7 @@ button:hover,
     z-index:6;
     margin-right:calc(var(--heatmap-frozen-axis-width) * -1);
     background:#111916;
-    pointer-events:none;
+    pointer-events:auto;
   }
 
   #main-svg,

--- a/src/plot/br-heatmap.ts
+++ b/src/plot/br-heatmap.ts
@@ -35,6 +35,7 @@ export class BrHeatmap extends Plot {
     colorMaps: BrHeatColorMap | null = null;
     private frozenAxisSvg!: d3.Selection<SVGSVGElement, unknown, HTMLElement, any>;
     private frozenAxisG!: d3.Selection<SVGGElement, unknown, HTMLElement, any>;
+    private focusedBr: string | null = null;
 
     selected: Array<SquareInfo> = [];
 
@@ -208,6 +209,8 @@ export class BrHeatmap extends Plot {
 
         // reset selected data and sub plots
         this.selected = [];
+        this.focusedBr = null;
+        this.applyBrFocus();
         await this.resetSubPlots();
 
         // sort the tooltip in the top layer
@@ -260,6 +263,8 @@ export class BrHeatmap extends Plot {
             .style("stroke", HEATMAP_CELL_STROKE)
             .style("cursor", d => d.value > 0 ? "pointer" : "default");
 
+        this.applyBrFocus();
+
         if (transition) {
             merged.transition()
                 .style("fill", d => this.value2color(d.value));
@@ -295,13 +300,13 @@ export class BrHeatmap extends Plot {
             .select("#main-g g path.domain").remove()
 
         // y-axis
-        this.g.append("g")
+        const yAxis = this.g.append("g")
             .attr("id", "br-heatmap-y")
             .attr("class", "heatmap-axis heatmap-axis-y")
             .style("font-size", 14)
             .attr("transform", `translate(-5, 0)`)
             .call(d3.axisLeft(y).tickSize(0))
-            .select("#main-g g path.domain").remove()
+        yAxis.select("path.domain").remove();
 
         this.frozenAxisG
             .selectAll("*")
@@ -311,7 +316,46 @@ export class BrHeatmap extends Plot {
             .call(d3.axisLeft(y).tickSize(0))
             .select("path.domain")
             .remove();
+        this.bindBrAxisInteractions(yAxis);
+        this.bindBrAxisInteractions(this.frozenAxisG);
         return {x, y};
+    }
+
+    private bindBrAxisInteractions(axis: d3.Selection<SVGGElement, unknown, HTMLElement, any>): void {
+        axis.selectAll<SVGGElement, string>(".tick")
+            .attr("role", "button")
+            .attr("tabindex", 0)
+            .attr("aria-label", br => `Focus BR ${br} row`)
+            .attr("aria-pressed", br => String(this.focusedBr === br))
+            .classed("is-br-focused", br => this.focusedBr === br)
+            .on("click.br-focus", br => this.toggleBrFocus(br))
+            .on("keydown.br-focus", br => {
+                if (d3.event.key !== "Enter" && d3.event.key !== " ") return;
+                d3.event.preventDefault();
+                this.toggleBrFocus(br);
+            });
+    }
+
+    private toggleBrFocus(br: string): void {
+        this.focusedBr = this.focusedBr === br ? null : br;
+        this.applyBrFocus();
+    }
+
+    private applyBrFocus(): void {
+        if (!this.g) return;
+
+        this.g.selectAll<SVGRectElement, SquareInfo>("rect")
+            .classed("is-br-dimmed", d => this.focusedBr !== null && d.br !== this.focusedBr)
+            .classed("is-br-focused", d => this.focusedBr === d.br);
+
+        [this.g.select<SVGGElement>("#br-heatmap-y"), this.frozenAxisG]
+            .forEach(axis => {
+                if (!axis || axis.empty()) return;
+                axis.selectAll<SVGGElement, string>(".tick")
+                    .attr("aria-pressed", br => String(this.focusedBr === br))
+                    .classed("is-br-focused", br => this.focusedBr === br)
+                    .classed("is-br-dimmed", br => this.focusedBr !== null && br !== this.focusedBr);
+            });
     }
 
     private extractData(data: Array<TimeseriesRow>): Array<SquareInfo> {


### PR DESCRIPTION
## What changed
- makes desktop and frozen mobile BR labels clickable and keyboard accessible
- dims every non-selected heatmap row while keeping the chosen BR fully lit
- toggles focus off by selecting the active BR again
- clears row focus when heatmap filters change

## Validation
- npm run build:pages
- npm run check:dist
- git diff --check

The automated mobile browser connection was unavailable and the local Playwright runner hung before test execution; production compilation and artifact validation passed.