### PR TITLE
Streamline navigation and vehicle cards

### DIFF
--- a/index.css
+++ b/index.css
@@ -1263,16 +1263,20 @@ body:not(.dark-mode) .vehicle-card{
 
 .vehicle-art img.fit-cover{
   object-fit:cover;
+  transform:scale(1.06);
+  transform-origin:center center;
 }
 
 .vehicle-art img.fit-contain{
   object-fit:contain;
+  transform:none;
   padding:8px;
   background:radial-gradient(circle at 50% 45%, rgba(137,221,255,.12), rgba(4,8,12,.72) 68%);
 }
 
 .vehicle-art.using-fallback-image img{
   object-fit:contain;
+  transform:none;
   padding:8px;
 }
 

--- a/src/app/ground-rb-panel.ts
+++ b/src/app/ground-rb-panel.ts
@@ -189,7 +189,7 @@ export class GroundRbPanel {
                         ["premium", "Premium"],
                         ["regular", "Non-premium"]
                     ])}
-                    ${this.numberInput("ground-min-battles", "Min battles", "0", "100000", "100", "500")}
+                    ${this.numberInput("ground-min-battles", "Min battles", "0", "100000", "100", "400")}
                     <label class="search-label">Vehicle search
                         <input id="ground-search" type="search" placeholder="XM1, Leopard 2, T-80..." autocomplete="off" aria-label="Search vehicles">
                     </label>
@@ -637,7 +637,7 @@ export class GroundRbPanel {
         (this.byId("ground-br-min") as HTMLInputElement).value = "0";
         (this.byId("ground-br-max") as HTMLInputElement).value = "13.7";
         (this.byId("ground-premium") as HTMLSelectElement).value = preset === "premium" ? "premium" : "all";
-        (this.byId("ground-min-battles") as HTMLInputElement).value = preset === "sample" ? "2000" : "500";
+        (this.byId("ground-min-battles") as HTMLInputElement).value = preset === "sample" ? "2000" : "400";
         (this.byId("ground-search") as HTMLInputElement).value = "";
         this.currentSort = preset === "played" ? "played" : preset === "frags" ? "gkb" : preset === "win" ? "win" : "gkd";
         (this.byId("ground-sort") as HTMLSelectElement).value = this.currentSort;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,17 +1,14 @@
 import { Application } from "./app/application";
 import { BRHeatMapPage } from "./app/page/br-heatmap-page";
 import { StackedAreaPage } from "./app/page/stacked-area-page";
-import { TodoPage } from "./app/page/todo-page";
 import { WebRepo } from "./app/link/web-repo";
 import { DataRepo } from "./app/link/data-repo";
 import { Logo } from "./app/image/logo";
-import { GithubIssue } from "./app/link/github-issue";
-import { Forum } from "./app/link/forum";
 import { DarkModeToggle } from "./app/link/dark-mode-toggle";
 
 Application.build
     .withLogo(Logo)
-    .withPages(BRHeatMapPage, StackedAreaPage, TodoPage)
-    .withLinks(WebRepo, DataRepo, GithubIssue, Forum, DarkModeToggle)
+    .withPages(BRHeatMapPage, StackedAreaPage)
+    .withLinks(WebRepo, DataRepo, DarkModeToggle)
     .class
     .run()


### PR DESCRIPTION
## What changed
- removes Todo List, Feedback, and Forum from the navigation
- changes the default and preset-reset Min Battles threshold from 500 to 400
- applies a centered, restrained zoom to wide vehicle card images while preserving centered contain-mode fallbacks

## Validation
- npm run build:pages
- npm run check:dist
- headless Chromium DOM verification at mobile width
- confirmed the app renders without startup errors
- confirmed removed links are absent and Min Battles defaults to 400