### PR TITLE
Polish dark cards and mobile table

### DIFF
--- a/index.css
+++ b/index.css
@@ -1263,7 +1263,7 @@ body:not(.dark-mode) .vehicle-card{
 
 .vehicle-art img.fit-cover{
   object-fit:cover;
-  transform:scale(1.06);
+  transform:translateX(8%) scale(1.18);
   transform-origin:center center;
 }
 
@@ -2279,6 +2279,38 @@ body:not(.dark-mode) .vehicle-card{
 .ground-rb-results-wrap{
   border-radius:14px;
   background:var(--panel);
+  isolation:isolate;
+}
+
+.ground-rb-results{
+  border-collapse:separate;
+  border-spacing:0;
+}
+
+.ground-rb-results th:first-child,
+.ground-rb-results td:first-child{
+  position:sticky;
+  left:0;
+  min-width:190px;
+  background:var(--panel);
+  box-shadow:8px 0 14px -12px rgba(0,0,0,.8);
+}
+
+.ground-rb-results th:first-child{
+  z-index:4;
+  background:color-mix(in srgb, var(--panel-strong) 88%, var(--accent) 12%);
+}
+
+.ground-rb-results td:first-child{
+  z-index:2;
+}
+
+.ground-rb-results tbody tr:nth-child(even) td:first-child{
+  background:var(--row-alt);
+}
+
+.ground-rb-results tbody tr:hover td:first-child{
+  background:var(--row-hover);
 }
 
 .ground-rb-results th,

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
           data-cf-beacon='{"token":"ba266901949a43388e3e08ffc263df47"}'></script>
   <!-- End Cloudflare Web Analytics -->
 </head>
-<body>
+<body class="dark-mode">
   <ul id="navbar"></ul>
 
   <div id="main-div">

--- a/src/app/ground-rb-panel.ts
+++ b/src/app/ground-rb-panel.ts
@@ -483,13 +483,6 @@ export class GroundRbPanel {
                         <h3>${this.displayName(row)}</h3>
                         <span class="result-rank">#${rank}</span>
                     </div>
-                    <div class="badge-row">
-                        <span>BR ${this.formatValue(row.rb_br)}</span>
-                        <span>${this.escape(row.nation)}</span>
-                        <span>${this.escape(this.typeLabel(row))}</span>
-                        <span>Rank N/A</span>
-                        ${this.isPremium(row) ? "<span class=\"premium-badge\">Premium</span>" : ""}
-                    </div>
                     <dl class="stat-grid">
                         ${this.stat("Battles", this.formatCount(row.rb_battles))}
                         ${this.stat("Win rate", this.formatPercentage(row.rb_win_rate))}

--- a/src/app/link/dark-mode-toggle.ts
+++ b/src/app/link/dark-mode-toggle.ts
@@ -22,9 +22,10 @@ export class DarkModeToggle extends Link {
             .attr("type", "checkbox")
             .attr("id", this.id);
 
-        const saved = localStorage.getItem(this.id) === "true";
-        this.checkbox.property("checked", saved);
-        this.applyMode(saved);
+        const stored = localStorage.getItem(this.id);
+        const enabled = stored === null ? true : stored === "true";
+        this.checkbox.property("checked", enabled);
+        this.applyMode(enabled);
 
         this.checkbox.on("change", () => {
             const checked = this.checkbox.property("checked") as boolean;


### PR DESCRIPTION
## What changed
- makes dark mode the default for visitors without a saved preference while preserving explicit light-mode choices
- removes the redundant badge row beneath each vehicle card title
- shifts and crops wide wiki images to center the vehicle subject more consistently
- freezes the Vehicle column on the left of the horizontally scrolling Ground RB table
- preserves sticky-cell backgrounds for alternating and hovered rows

## Validation
- npm run build:pages
- npm run check:dist
- headless Chromium mobile render
- confirmed default dark mode, no redundant badge rows, successful startup, and no runtime injection errors